### PR TITLE
Update Text Styling Parameters

### DIFF
--- a/packages/url-loader/src/constants/qualifiers.ts
+++ b/packages/url-loader/src/constants/qualifiers.ts
@@ -35,8 +35,11 @@ export const position: Record<string, Qualifier> = {
 
 export const text: Record<string, Qualifier> = {
   alignment: {
-    qualifier: 'alignment',
+    qualifier: false,
     order: 6
+  },
+  antialias: {
+    qualifier: 'antialias'
   },
   border: {
     qualifier: 'bo',
@@ -61,6 +64,9 @@ export const text: Record<string, Qualifier> = {
   fontWeight: {
     qualifier: false,
     order: 3
+  },
+  hinting: {
+    qualifier: 'hinting'
   },
   letterSpacing: {
     qualifier: 'letter_spacing'

--- a/packages/url-loader/tests/plugins/overlays.spec.js
+++ b/packages/url-loader/tests/plugins/overlays.spec.js
@@ -246,22 +246,32 @@ describe('Plugins', () => {
     it('should add a stroke to text', () => {
       const cldImage = cld.image(TEST_PUBLIC_ID);
 
+      const alignment = 'right';
+      const antialias = 'best';
       const color = 'white';
       const fontFamily = 'Source Sans Pro';
       const fontSize = 200;
       const fontStyle = 'italic';
       const fontWeight = 'bold';
+      const hinting = 'slight';
+      const letterSpacing = 12;
+      const lineSpacing = -12;
       const text = 'Next Cloudinary';
       const border = '20px_solid_blue';
       const stroke = true;
 
       const options = {
         text: {
+          alignment,
+          antialias,
           color,
           fontFamily,
           fontSize,
           fontStyle,
           fontWeight,
+          hinting,
+          letterSpacing,
+          lineSpacing,
           text,
           border,
           stroke
@@ -273,7 +283,7 @@ describe('Plugins', () => {
         options
       });
 
-      expect(cldImage.toURL()).toContain(`l_text:${encodeURIComponent(fontFamily)}_${fontSize}_${fontWeight}_${fontStyle}_stroke:${encodeURIComponent(text)},co_${color},bo_${border}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
+      expect(cldImage.toURL()).toContain(`l_text:${encodeURIComponent(fontFamily)}_${fontSize}_${fontWeight}_${fontStyle}_${alignment}_stroke_antialias_${antialias}_hinting_${hinting}_letter_spacing_${letterSpacing}_line_spacing_${lineSpacing}:${encodeURIComponent(text)},co_${color},bo_${border}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
     });
 
     it('should add a stroke to text', () => {


### PR DESCRIPTION
# Description

Updates and adds all styling parameter options available for text.

https://cloudinary.com/documentation/transformation_reference#l_text

## Issue Ticket Number

Fixes #9 

See https://github.com/colbyfayock/next-cloudinary/issues/108

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
