### PR TITLE
Fixes Query Param Breaking Parsing

### DIFF
--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -1,2 +1,4 @@
 export { parseUrl, getPublicId, getTransformations } from './lib/cloudinary';
+export type { ParseUrl } from './lib/cloudinary';
+
 export { encodeBase64, objectHasKey, sortByKey } from './lib/util';

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -6,7 +6,7 @@ const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetTyp
  * @description
  */
 
-interface ParseUrl {
+export interface ParseUrl {
   assetType?: string;
   cloudName?: string;
   deliveryType?: string;
@@ -15,7 +15,7 @@ interface ParseUrl {
   id?: string;
   signature?: string;
   transformations?: Array<string>;
-  query?: object;
+  queryParams?: object;
   version?: string;
 }
 

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -15,6 +15,7 @@ interface ParseUrl {
   id?: string;
   signature?: string;
   transformations?: Array<string>;
+  query?: object;
   version?: string;
 }
 
@@ -29,11 +30,26 @@ export function parseUrl(src: string): ParseUrl | undefined {
     throw new Error(`Invalid src: Does not include version (Ex: /v1234/)`);
   }
 
-  const results = src.match(REGEX_URL);
+  const [baseUrl, queryString] = src.split('?');
+
+  const results = baseUrl.match(REGEX_URL);
 
   const parts = {
     ...results?.groups,
-    transformations: results?.groups?.transformations.split('/').filter(t => !!t)
+    transformations: results?.groups?.transformations.split('/').filter(t => !!t),
+    queryParams: {}
+  }
+
+  if ( queryString ) {
+    interface QueryParams {
+      [key: string]: string | undefined;
+    }
+
+    parts.queryParams = queryString.split('&').reduce((prev: QueryParams, curr: string) => {
+      const [key, value] = curr.split('=');
+      prev[key] = value;
+      return prev;
+    }, {});
   }
 
   return parts;

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -122,6 +122,38 @@ describe('Cloudinary', () => {
         version,
       });
     });
+
+    it('should parse a Cloudinary URL with query parameters', () => {
+      const assetType = 'video';
+      const cloudName = 'test-cloud';
+      const deliveryType = 'upload';
+      const format = '.mp4';
+      const host = 'res.cloudinary.com';
+      const id = 'assets/images/animals/turtle';
+      const signature = undefined;
+      const transformations = ['f_auto,q_auto'];
+      const version = 'v1234';
+      const queryParams = {
+        _i: 'AA',
+        _a: 'AVAADAN0'
+      }
+
+      const queryString = Object.keys(queryParams).map(key => `${key}=${queryParams[key]}`).join('&');
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${id}${format}?${queryString}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        format,
+        host,
+        id,
+        signature,
+        transformations,
+        version,
+        queryParams
+      });
+    });
   });
 
   describe('getPublicId', () => {


### PR DESCRIPTION
# Description

Query parameters prevent parsing of the URL to to it being unaccounted for. This prevents this and reads the value into the URL parts in case the parameters are wanted to be used.

## Issue Ticket Number

Fixes #15 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
