### PR TITLE
Adds Test for URL Loader Cloudinary URL

### DIFF
--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -50,6 +50,30 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/${src}`);
     });
 
+    it('should create a Cloudinary URL from a Cloudinary source', () => {
+      const cloudName = 'customtestcloud';
+      const deliveryType = 'fetch';
+      const publicId = 'myimage';
+
+      const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+          deliveryType
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+      // TODO: should library be adding a version to URLs?
+      expect(url).toContain(src.replace('/v1234', ''));
+    });
+
     it('should create a Cloudinary URL with custom quality and format options', () => {
       const format = 'png';
       const quality = 75;


### PR DESCRIPTION
# Description

Adds a test to capture URL source for URL generator

Partially doing this to trigger a new URL Loader release.

## Issue Ticket Number

Fixes #15 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
