### PR TITLE
Parse SEO URLs & SEO Suffix

### DIFF
--- a/packages/url-loader/src/constants/url.ts
+++ b/packages/url-loader/src/constants/url.ts
@@ -1,0 +1,18 @@
+interface AssetType {
+  seo?: boolean;
+}
+
+export const assetTypes: Record<string, AssetType> = {
+  image: {},
+  images: {
+    seo: true
+  },
+  video: {},
+  videos: {
+    seo: true
+  },
+  raw: {},
+  files: {
+    seo: true
+  },
+} as const;

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -1,5 +1,5 @@
 import { Cloudinary } from '@cloudinary/url-gen';
-import { parseUrl, ParseUrl } from '@cloudinary-util/util';
+import { parseUrl, ParseUrl, objectHasKey } from '@cloudinary-util/util';
 import ICloudinaryConfigurations from '@cloudinary/url-gen/config/interfaces/Config/ICloudinaryConfigurations';
 import { IAnalyticsOptions } from '@cloudinary/url-gen/sdkAnalytics/interfaces/IAnalyticsOptions';
 
@@ -13,9 +13,6 @@ import * as seoPlugin from '../plugins/seo';
 import * as underlaysPlugin from '../plugins/underlays';
 import * as versionPlugin from '../plugins/version';
 import * as zoompanPlugin from '../plugins/zoompan';
-
-import { objectHasKey } from '@cloudinary-util/util';
-import { assetTypes } from '../constants/url';
 
 import { ImageOptions } from '../types/image';
 

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -1,5 +1,7 @@
 import { Cloudinary } from '@cloudinary/url-gen';
-import { getPublicId } from '@cloudinary-util/util';
+import { parseUrl, ParseUrl } from '@cloudinary-util/util';
+import ICloudinaryConfigurations from '@cloudinary/url-gen/config/interfaces/Config/ICloudinaryConfigurations';
+import { IAnalyticsOptions } from '@cloudinary/url-gen/sdkAnalytics/interfaces/IAnalyticsOptions';
 
 import * as croppingPlugin from '../plugins/cropping';
 import * as effectsPlugin from '../plugins/effects';
@@ -7,13 +9,15 @@ import * as overlaysPlugin from '../plugins/overlays';
 import * as namedTransformationsPlugin from '../plugins/named-transformations';
 import * as rawTransformationsPlugin from '../plugins/raw-transformations';
 import * as removeBackgroundPlugin from '../plugins/remove-background';
+import * as seoPlugin from '../plugins/seo';
 import * as underlaysPlugin from '../plugins/underlays';
+import * as versionPlugin from '../plugins/version';
 import * as zoompanPlugin from '../plugins/zoompan';
 
-import { ImageOptions } from '../types/image';
+import { objectHasKey } from '@cloudinary-util/util';
+import { assetTypes } from '../constants/url';
 
-import ICloudinaryConfigurations from '@cloudinary/url-gen/config/interfaces/Config/ICloudinaryConfigurations';
-import { IAnalyticsOptions } from '@cloudinary/url-gen/sdkAnalytics/interfaces/IAnalyticsOptions';
+import { ImageOptions } from '../types/image';
 
 export const transformationPlugins = [
   // Background Removal must always come first
@@ -23,7 +27,9 @@ export const transformationPlugins = [
   effectsPlugin,
   overlaysPlugin,
   namedTransformationsPlugin,
+  seoPlugin,
   underlaysPlugin,
+  versionPlugin,
   zoompanPlugin,
 
   // Raw transformations needs to be last simply to make sure
@@ -68,6 +74,11 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     throw Error(`Failed to construct Cloudinary URL: Missing source (src) in options`);
   }
 
+  const parsedOptions: Pick<ParseUrl, 'seoSuffix' | 'version'> = {
+    seoSuffix: undefined,
+    version: undefined,
+  };
+
   let publicId;
 
   // If the src starts with https, try to parse the URL to grab the ID dynamically
@@ -76,13 +87,26 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
 
   if ( options.src.startsWith('https://') ) {
     try {
-      publicId = getPublicId(options.src);
+      const parts = parseUrl(options.src);
+      publicId = parts?.publicId;
+      parsedOptions.seoSuffix = parts?.seoSuffix;
+      parsedOptions.version = parts?.version;
     } catch(e) {}
   }
 
   if ( !publicId ) {
     publicId = options.src;
   }
+
+  // Take all the parsed URL parts and apply them to the options configuration
+  // if there isn't an existing override
+
+  (Object.keys(parsedOptions) as Array<keyof typeof parsedOptions>).forEach((key) => {
+    if ( objectHasKey(options, key) ) return;
+    options[key] = parsedOptions[key];
+  })
+
+  // Begin creating a new Cloudinary image instance and configure
 
   const cldImage = cld.image(publicId);
 
@@ -110,11 +134,14 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     cldImage.effect(`c_${crop},w_${width}`);
   }
 
-  return cldImage
-          .setDeliveryType(options?.deliveryType || 'upload')
-          .format(options?.format || 'auto')
-          .delivery(`q_${options?.quality || 'auto'}`)
-          .toURL({
+  cldImage
+    .setDeliveryType(options?.deliveryType || 'upload')
+    .format(options?.format || 'auto')
+    .delivery(`q_${options?.quality || 'auto'}`)
+
+
+
+  return cldImage.toURL({
             trackedAnalytics: analytics
           });
 }

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -101,7 +101,7 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
   (Object.keys(parsedOptions) as Array<keyof typeof parsedOptions>).forEach((key) => {
     if ( objectHasKey(options, key) ) return;
     options[key] = parsedOptions[key];
-  })
+  });
 
   // Begin creating a new Cloudinary image instance and configure
 
@@ -131,14 +131,11 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     cldImage.effect(`c_${crop},w_${width}`);
   }
 
-  cldImage
-    .setDeliveryType(options?.deliveryType || 'upload')
-    .format(options?.format || 'auto')
-    .delivery(`q_${options?.quality || 'auto'}`)
-
-
-
-  return cldImage.toURL({
+  return cldImage
+          .setDeliveryType(options?.deliveryType || 'upload')
+          .format(options?.format || 'auto')
+          .delivery(`q_${options?.quality || 'auto'}`)
+          .toURL({
             trackedAnalytics: analytics
           });
 }

--- a/packages/url-loader/src/plugins/seo.ts
+++ b/packages/url-loader/src/plugins/seo.ts
@@ -1,0 +1,16 @@
+import { PluginSettings } from '../types/plugins';
+
+export const props = [
+  'seoSuffix'
+];
+
+export function plugin(props: PluginSettings) {
+  const { cldImage, options } = props;
+  const { seoSuffix } = options;
+
+  if ( typeof seoSuffix === 'string' ) {
+    cldImage.setSuffix(seoSuffix);
+  }
+
+  return {};
+}

--- a/packages/url-loader/src/plugins/version.ts
+++ b/packages/url-loader/src/plugins/version.ts
@@ -6,8 +6,10 @@ export function plugin(props: PluginSettings) {
   const { cldImage, options } = props;
   const { version } = options;
 
-  if ( typeof version === 'string' ) {
-    cldImage.setVersion(version.replace('v', ''));
+  if ( typeof version === 'string' || typeof version === 'number' ) {
+    // Replace a `v` in the string just in case the caller
+    // passes it in
+    cldImage.setVersion(`${version}`.replace('v', ''));
   }
 
   return {};

--- a/packages/url-loader/src/plugins/version.ts
+++ b/packages/url-loader/src/plugins/version.ts
@@ -1,0 +1,14 @@
+import { PluginSettings } from '../types/plugins';
+
+export const props = ['version'];
+
+export function plugin(props: PluginSettings) {
+  const { cldImage, options } = props;
+  const { version } = options;
+
+  if ( typeof version === 'string' ) {
+    cldImage.setVersion(version.replace('v', ''));
+  }
+
+  return {};
+}

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -8,6 +8,7 @@ export interface ImageOptionsZoomPan {
 }
 
 export interface ImageOptions {
+  assetType?: string;
   crop?: string;
   deliveryType?: string;
   effects?: Array<any>;
@@ -19,11 +20,13 @@ export interface ImageOptions {
   rawTransformations?: string[];
   removeBackground?: boolean;
   resize?: ImageOptionsResize;
+  seoSuffix?: string;
   src: string;
   text?: any;
   transformations?: Array<string>;
   underlay?: string;
   underlays?: Array<any>;
+  version?: string;
   width?: string | number;
   widthResize?: string;
   zoom?: string;

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -26,7 +26,7 @@ export interface ImageOptions {
   transformations?: Array<string>;
   underlay?: string;
   underlays?: Array<any>;
-  version?: string;
+  version?: number | string;
   width?: string | number;
   widthResize?: string;
   zoom?: string;

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -70,8 +70,81 @@ describe('Cloudinary', () => {
           }
         }
       });
-      // TODO: should library be adding a version to URLs?
-      expect(url).toContain(src.replace('/v1234', ''));
+
+      expect(url).toContain(src);
+    });
+
+    it('should create a Cloudinary URL with an SEO suffix', () => {
+      const cloudName = 'customtestcloud';
+      const publicId = 'myimage';
+      const seoSuffix = 'test-image';
+
+      const src = `https://res.cloudinary.com/${cloudName}/images/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${seoSuffix}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+          seoSuffix
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+
+      expect(url).toContain(src);
+    });
+
+    it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes', () => {
+      const cloudName = 'customtestcloud';
+      const assetType = 'images';
+      const publicId = 'myimage/my-image';
+
+      const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+
+      expect(url).toContain(src);
+    });
+
+    it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes and overriding', () => {
+      const cloudName = 'customtestcloud';
+      const assetType = 'images';
+      const publicId = 'myimage';
+      const originalSeoSuffix = 'my-image'
+      const seoSuffix = 'test-image';
+
+      const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${originalSeoSuffix}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+          seoSuffix
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+
+      expect(url).toContain(src.replace(originalSeoSuffix, seoSuffix));
     });
 
     it('should create a Cloudinary URL with custom quality and format options', () => {
@@ -93,6 +166,26 @@ describe('Cloudinary', () => {
         }
       });
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_${format}/q_${quality}/turtle`);
+    });
+
+    it('should add a custom version to a URL', () => {
+      const cloudName = 'customtestcloud';
+      const version = '1029384756';
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src: 'turtle',
+          version
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+      // Only match the analytics version (A) and the ID as the rest is determined
+      // dynamically by SDK and Next.js version
+      expect(url).toContain(`/v${version}/`);
     });
 
     it('should include an analytics ID at the end of the URL', () => {

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -50,6 +50,30 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/${src}`);
     });
 
+    it('should create a Cloudinary URL from a Cloudinary source', () => {
+      const cloudName = 'customtestcloud';
+      const deliveryType = 'fetch';
+      const publicId = 'myimage';
+
+      const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+          deliveryType
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+      // TODO: should library be adding a version to URLs?
+      expect(url).toContain(src.replace('/v1234', ''));
+    });
+
     it('should create a Cloudinary URL with custom quality and format options', () => {
       const format = 'png';
       const quality = 75;

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -170,7 +170,7 @@ describe('Cloudinary', () => {
 
     it('should add a custom version to a URL', () => {
       const cloudName = 'customtestcloud';
-      const version = '1029384756';
+      const version = 1029384756;
 
       const url = constructCloudinaryUrl({
         options: {

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -19,7 +19,7 @@ export interface ParseUrl {
   seoSuffix?: string;
   transformations?: Array<string>;
   queryParams?: object;
-  version?: string;
+  version?: number;
 }
 
 export function parseUrl(src: string): ParseUrl | undefined {
@@ -43,6 +43,7 @@ export function parseUrl(src: string): ParseUrl | undefined {
     seoSuffix: undefined,
     transformations: transformations || [],
     queryParams: {},
+    version: results?.groups?.version ? parseInt(results.groups.version.replace('v', '')) : undefined
   }
 
   if ( queryString ) {

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -1,5 +1,5 @@
 const REGEX_VERSION = /\/v\d+\//;
-const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|video|raw)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)\/?(?<signature>s\-\-[a-zA-Z0-9]+\-\-)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)+(?<version>v\d+|\w{1,2})\/(?<id>[^\.^\s]+)(?<format>\.[a-zA-Z0-9]+$)?$/;
+const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s\-\-[a-zA-Z0-9]+\-\-)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<id>[^\.^\s]+)(?<format>\.[a-zA-Z0-9]+$)?$/;
 
 /**
  * parseUrl
@@ -33,10 +33,11 @@ export function parseUrl(src: string): ParseUrl | undefined {
   const [baseUrl, queryString] = src.split('?');
 
   const results = baseUrl.match(REGEX_URL);
+  const transformations = results?.groups?.transformations?.split('/').filter(t => !!t);
 
   const parts = {
     ...results?.groups,
-    transformations: results?.groups?.transformations.split('/').filter(t => !!t),
+    transformations: transformations || [],
     queryParams: {}
   }
 

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -168,6 +168,12 @@ describe('Cloudinary', () => {
       const src = `https://res.cloudinary.com/test-cloud/image/upload/c_limit,w_960/f_auto/q_auto/v1/${publicId}`;
       expect(getPublicId(src)).toBe(publicId);
     });
+
+    it('should return the public ID of a Cloudinary URL using SEO Suffixes', () => {
+      const publicId = 'ecommerce-with-nextjs-and-stripe/ecommerce-with-nextjs-and-stripe';
+      const src = `https://res.cloudinary.com/test-cloud/images/f_auto,q_auto/v1654624121/${publicId}.jpg?_i=AA`;
+      expect(getPublicId(src)).toBe(publicId);
+    });
   });
 
   describe('getTransformations', () => {

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -25,12 +25,12 @@ describe('Cloudinary', () => {
       const deliveryType = 'upload';
       const format = '.jpg';
       const host = 'res.cloudinary.com';
-      const id = 'turtle';
+      const publicId = 'turtle';
       const signature = 's--abc12345--';
       const transformations = ['c_limit,w_960'];
       const version = 'v1234';
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/${version}/${id}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -38,7 +38,7 @@ describe('Cloudinary', () => {
         deliveryType,
         format,
         host,
-        id,
+        publicId,
         signature,
         transformations,
         version,
@@ -51,12 +51,12 @@ describe('Cloudinary', () => {
       const deliveryType = 'fetch';
       const format = undefined;
       const host = 'res.cloudinary.com';
-      const id = 'images/turtle';
+      const publicId = 'images/turtle';
       const signature = undefined;
       const transformations = ['c_limit,w_960'];
       const version = 'v1234';
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${id}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -64,7 +64,7 @@ describe('Cloudinary', () => {
         deliveryType,
         format,
         host,
-        id,
+        publicId,
         signature,
         transformations,
         version,
@@ -77,12 +77,12 @@ describe('Cloudinary', () => {
       const deliveryType = 'upload';
       const format = '.mp4';
       const host = 'res.cloudinary.com';
-      const id = 'assets/images/animals/turtle';
+      const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['c_limit,w_960'];
       const version = 'v1234';
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${id}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -90,7 +90,7 @@ describe('Cloudinary', () => {
         deliveryType,
         format,
         host,
-        id,
+        publicId,
         signature,
         transformations,
         version,
@@ -103,12 +103,12 @@ describe('Cloudinary', () => {
       const deliveryType = 'upload';
       const format = '.mp4';
       const host = 'res.cloudinary.com';
-      const id = 'assets/images/animals/turtle';
+      const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['f_auto,q_auto', 'c_limit,w_960'];
       const version = 'v1234';
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${id}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -116,7 +116,7 @@ describe('Cloudinary', () => {
         deliveryType,
         format,
         host,
-        id,
+        publicId,
         signature,
         transformations,
         version,
@@ -129,7 +129,7 @@ describe('Cloudinary', () => {
       const deliveryType = 'upload';
       const format = '.mp4';
       const host = 'res.cloudinary.com';
-      const id = 'assets/images/animals/turtle';
+      const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['f_auto,q_auto'];
       const version = 'v1234';
@@ -139,7 +139,7 @@ describe('Cloudinary', () => {
       }
 
       const queryString = Object.keys(queryParams).map(key => `${key}=${queryParams[key]}`).join('&');
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${id}${format}?${queryString}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}?${queryString}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -147,11 +147,39 @@ describe('Cloudinary', () => {
         deliveryType,
         format,
         host,
-        id,
+        publicId,
         signature,
         transformations,
         version,
         queryParams
+      });
+    });
+
+    it('should parse a Cloudinary URL with SEO suffix', () => {
+      const assetType = 'videos';
+      const cloudName = 'test-cloud';
+      const deliveryType = undefined;
+      const format = '.mp4';
+      const host = 'res.cloudinary.com';
+      const publicId = 'assets/images/animals/turtle';
+      const seoSuffix = 'cool-turtles';
+      const signature = undefined;
+      const transformations = ['f_auto,q_auto'];
+      const version = 'v1234';
+
+      const src = `https://${host}/${cloudName}/${assetType}/${transformations.join('/')}/${version}/${publicId}/${seoSuffix}${format}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        format,
+        host,
+        publicId,
+        seoSuffix,
+        signature,
+        transformations,
+        version,
       });
     });
   });
@@ -170,8 +198,9 @@ describe('Cloudinary', () => {
     });
 
     it('should return the public ID of a Cloudinary URL using SEO Suffixes', () => {
-      const publicId = 'ecommerce-with-nextjs-and-stripe/ecommerce-with-nextjs-and-stripe';
-      const src = `https://res.cloudinary.com/test-cloud/images/f_auto,q_auto/v1654624121/${publicId}.jpg?_i=AA`;
+      const publicId = 'ecommerce-with-nextjs-and-stripe';
+      const seoSuffix = 'my-seo-suffix'
+      const src = `https://res.cloudinary.com/test-cloud/images/f_auto,q_auto/v1654624121/${publicId}/${seoSuffix}.jpg?_i=AA`;
       expect(getPublicId(src)).toBe(publicId);
     });
   });

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -28,9 +28,9 @@ describe('Cloudinary', () => {
       const publicId = 'turtle';
       const signature = 's--abc12345--';
       const transformations = ['c_limit,w_960'];
-      const version = 'v1234';
+      const version = 1234;
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/${version}/${publicId}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/v${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -54,9 +54,9 @@ describe('Cloudinary', () => {
       const publicId = 'images/turtle';
       const signature = undefined;
       const transformations = ['c_limit,w_960'];
-      const version = 'v1234';
+      const version = 1234;
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/v${version}/${publicId}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -80,9 +80,9 @@ describe('Cloudinary', () => {
       const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['c_limit,w_960'];
-      const version = 'v1234';
+      const version = 1234;
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/v${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -106,9 +106,9 @@ describe('Cloudinary', () => {
       const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['f_auto,q_auto', 'c_limit,w_960'];
-      const version = 'v1234';
+      const version = 1234;
 
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/v${version}/${publicId}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -132,14 +132,14 @@ describe('Cloudinary', () => {
       const publicId = 'assets/images/animals/turtle';
       const signature = undefined;
       const transformations = ['f_auto,q_auto'];
-      const version = 'v1234';
+      const version = 1234;
       const queryParams = {
         _i: 'AA',
         _a: 'AVAADAN0'
       }
 
       const queryString = Object.keys(queryParams).map(key => `${key}=${queryParams[key]}`).join('&');
-      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/${version}/${publicId}${format}?${queryString}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${transformations.join('/')}/v${version}/${publicId}${format}?${queryString}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,
@@ -165,9 +165,9 @@ describe('Cloudinary', () => {
       const seoSuffix = 'cool-turtles';
       const signature = undefined;
       const transformations = ['f_auto,q_auto'];
-      const version = 'v1234';
+      const version = 1234;
 
-      const src = `https://${host}/${cloudName}/${assetType}/${transformations.join('/')}/${version}/${publicId}/${seoSuffix}${format}`;
+      const src = `https://${host}/${cloudName}/${assetType}/${transformations.join('/')}/v${version}/${publicId}/${seoSuffix}${format}`;
 
       expect(parseUrl(src)).toMatchObject({
         assetType,


### PR DESCRIPTION
# Description

Cloudinary allows the ability to create SEO friendly URLs using the SEO Suffix option

This changes the asset type for example /image/upload => /images

This PR allows for the parsing of this and adds the ability to pass in an SEO suffix.

This also updates version management in how it parses and now allows someone to pass in a version


```
options: {
   seoSuffix: 'my-friendly-url',
  version: 1234
}
```

## Issue Ticket Number

Fixes #18 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation

BREAKING CHANGES: "version" is returned as a number from parseUrl. "id" is now named "publicId" when returned from parseUrl