### PR TITLE
Fixes Raw Transformations Conflicting with Base Resize

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -19,7 +19,14 @@ import { ImageOptions } from '../types/image';
 
 export const transformationPlugins = [
   // Background Removal must always come first
+
   removeBackgroundPlugin,
+
+  // Raw transformations should always come before
+  // other arguments to avoid conflicting with
+  // added options via the component
+
+  rawTransformationsPlugin,
 
   croppingPlugin,
   effectsPlugin,
@@ -30,11 +37,6 @@ export const transformationPlugins = [
   underlaysPlugin,
   versionPlugin,
   zoompanPlugin,
-
-  // Raw transformations needs to be last simply to make sure
-  // it's always expected to applied the same way
-
-  rawTransformationsPlugin
 ];
 
 let cld: any;
@@ -127,6 +129,9 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
       };
     }
   });
+
+  // We want to perform any resizing at the end of the end of the transformation
+  // sets to allow consistent use of positioning / sizing, especially responsively
 
   if ( options?.resize ) {
     const { width, crop = 'scale' } = options.resize;

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -29,7 +29,7 @@ export interface ImageOptions {
   underlays?: Array<any>;
   version?: number | string;
   width?: string | number;
-  widthResize?: string;
+  widthResize?: string | number;
   zoom?: string;
   zoompan?: string | boolean | ImageOptionsZoomPan;
 }

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -7,5 +7,5 @@ export interface PluginSettings {
 
 export interface PluginOverrides {
   format?: string;
-  width?: string;
+  width?: number;
 }

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -13,6 +13,7 @@ describe('Cloudinary', () => {
   });
 
   describe('constructCloudinaryUrl', () => {
+
     it('should create a Cloudinary URL', () => {
       const cloudName = 'customtestcloud';
       const url = constructCloudinaryUrl({
@@ -30,183 +31,237 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
 
-    it('should create a Cloudinary URL with a remote source', () => {
-      const cloudName = 'customtestcloud';
-      const deliveryType = 'fetch';
-      const src = 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg';
-      const url = constructCloudinaryUrl({
-        options: {
-          src,
-          width: 100,
-          height: 100,
-          deliveryType
-        },
-        config: {
-          cloud: {
-            cloudName
+    /* Optimization */
+
+    describe('format, quality', () => {
+
+      it('should create a Cloudinary URL with custom quality and format options', () => {
+        const format = 'png';
+        const quality = 75;
+        const cloudName = 'customtestcloud';
+        const url = constructCloudinaryUrl({
+          options: {
+            src: 'turtle',
+            width: 100,
+            height: 100,
+            format,
+            quality
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
-      });
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/${src}`);
-    });
-
-    it('should create a Cloudinary URL from a Cloudinary source', () => {
-      const cloudName = 'customtestcloud';
-      const deliveryType = 'fetch';
-      const publicId = 'myimage';
-
-      const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
-
-      const url = constructCloudinaryUrl({
-        options: {
-          src,
-          width: 100,
-          height: 100,
-          deliveryType
-        },
-        config: {
-          cloud: {
-            cloudName
-          }
-        }
+        });
+        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_${format}/q_${quality}/turtle`);
       });
 
-      expect(url).toContain(src);
     });
 
-    it('should create a Cloudinary URL with an SEO suffix', () => {
-      const cloudName = 'customtestcloud';
-      const publicId = 'myimage';
-      const seoSuffix = 'test-image';
+    /* Delivery */
 
-      const src = `https://res.cloudinary.com/${cloudName}/images/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${seoSuffix}?_a=A`;
+    describe('deliveryType', () => {
 
-      const url = constructCloudinaryUrl({
-        options: {
-          src,
-          width: 100,
-          height: 100,
-          seoSuffix
-        },
-        config: {
-          cloud: {
-            cloudName
+      it('should create a Cloudinary URL with a remote source', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'fetch';
+        const src = 'https://upload.wikimedia.org/wikipedia/commons/4/44/Jelly_cc11.jpg';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+            deliveryType
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
+        });
+        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/${src}`);
       });
 
-      expect(url).toContain(src);
-    });
+      it('should create a Cloudinary URL from a Cloudinary source', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'fetch';
+        const publicId = 'myimage';
 
-    it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes', () => {
-      const cloudName = 'customtestcloud';
-      const assetType = 'images';
-      const publicId = 'myimage/my-image';
+        const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
 
-      const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
-
-      const url = constructCloudinaryUrl({
-        options: {
-          src,
-          width: 100,
-          height: 100,
-        },
-        config: {
-          cloud: {
-            cloudName
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+            deliveryType
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
+        });
+
+        expect(url).toContain(src);
       });
 
-      expect(url).toContain(src);
-    });
+    })
 
-    it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes and overriding', () => {
-      const cloudName = 'customtestcloud';
-      const assetType = 'images';
-      const publicId = 'myimage';
-      const originalSeoSuffix = 'my-image'
-      const seoSuffix = 'test-image';
+    /* SEO */
 
-      const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${originalSeoSuffix}?_a=A`;
+    describe('seoSuffix', () => {
 
-      const url = constructCloudinaryUrl({
-        options: {
-          src,
-          width: 100,
-          height: 100,
-          seoSuffix
-        },
-        config: {
-          cloud: {
-            cloudName
+      it('should create a Cloudinary URL with an SEO suffix', () => {
+        const cloudName = 'customtestcloud';
+        const publicId = 'myimage';
+        const seoSuffix = 'test-image';
+
+        const src = `https://res.cloudinary.com/${cloudName}/images/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${seoSuffix}?_a=A`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+            seoSuffix
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
+        });
+
+        expect(url).toContain(src);
       });
 
-      expect(url).toContain(src.replace(originalSeoSuffix, seoSuffix));
-    });
+      it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes', () => {
+        const cloudName = 'customtestcloud';
+        const assetType = 'images';
+        const publicId = 'myimage/my-image';
 
-    it('should create a Cloudinary URL with custom quality and format options', () => {
-      const format = 'png';
-      const quality = 75;
-      const cloudName = 'customtestcloud';
-      const url = constructCloudinaryUrl({
-        options: {
-          src: 'turtle',
-          width: 100,
-          height: 100,
-          format,
-          quality
-        },
-        config: {
-          cloud: {
-            cloudName
+        const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
+        });
+
+        expect(url).toContain(src);
       });
-      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_${format}/q_${quality}/turtle`);
-    });
 
-    it('should add a custom version to a URL', () => {
-      const cloudName = 'customtestcloud';
-      const version = 1029384756;
+      it('should create a Cloudinary URL from a Cloudinary source with SEO prefixes and overriding', () => {
+        const cloudName = 'customtestcloud';
+        const assetType = 'images';
+        const publicId = 'myimage';
+        const originalSeoSuffix = 'my-image'
+        const seoSuffix = 'test-image';
 
-      const url = constructCloudinaryUrl({
-        options: {
-          src: 'turtle',
-          version
-        },
-        config: {
-          cloud: {
-            cloudName
+        const src = `https://res.cloudinary.com/${cloudName}/${assetType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}/${originalSeoSuffix}?_a=A`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+            seoSuffix
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        }
+        });
+
+        expect(url).toContain(src.replace(originalSeoSuffix, seoSuffix));
       });
-      // Only match the analytics version (A) and the ID as the rest is determined
-      // dynamically by SDK and Next.js version
-      expect(url).toContain(`/v${version}/`);
+
     });
 
-    it('should include an analytics ID at the end of the URL', () => {
-      const cloudName = 'customtestcloud';
-      const sdkCode = 'V';
-      const url = constructCloudinaryUrl({
-        options: {
-          src: 'turtle',
-        },
-        config: {
-          cloud: {
-            cloudName
+    /* Versioning */
+
+    describe('version', () => {
+      it('should add a custom version to a URL', () => {
+        const cloudName = 'customtestcloud';
+        const version = 1029384756;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: 'turtle',
+            version
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
           }
-        },
-        analytics: {
-          sdkCode
-        }
+        });
+        // Only match the analytics version (A) and the ID as the rest is determined
+        // dynamically by SDK and Next.js version
+        expect(url).toContain(`/v${version}/`);
       });
-      // Only match the analytics version (A) and the ID as the rest is determined
-      // dynamically by SDK and Next.js version
-      expect(url).toContain(`?_a=A${sdkCode}`);
     });
+
+    /* Analytics */
+
+    describe('analytics', () => {
+
+      it('should include an analytics ID at the end of the URL', () => {
+        const cloudName = 'customtestcloud';
+        const sdkCode = 'V';
+        const url = constructCloudinaryUrl({
+          options: {
+            src: 'turtle',
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          },
+          analytics: {
+            sdkCode
+          }
+        });
+        // Only match the analytics version (A) and the ID as the rest is determined
+        // dynamically by SDK and Next.js version
+        expect(url).toContain(`?_a=A${sdkCode}`);
+      });
+
+    });
+
+    /* Raw Transformations */
+
+    describe('rawTransformations', () => {
+
+      it('should apply rawTransformations to the beginning of the URL', () => {
+        const cloudName = 'customtestcloud';
+        const src = 'turtle';
+        const rawTransformations = ['c_crop,h_359,w_517,x_1483,y_0/c_scale,h_359,w_517/f_auto,q_auto'];
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            rawTransformations
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`image/upload/${rawTransformations.join('/')}/f_auto/q_auto/${src}`);
+      });
+
+    })
+
+
   });
 });

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -50,6 +50,30 @@ describe('Cloudinary', () => {
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/${src}`);
     });
 
+    it('should create a Cloudinary URL from a Cloudinary source', () => {
+      const cloudName = 'customtestcloud';
+      const deliveryType = 'fetch';
+      const publicId = 'myimage';
+
+      const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/f_auto/q_auto/v1234/${publicId}?_a=A`;
+
+      const url = constructCloudinaryUrl({
+        options: {
+          src,
+          width: 100,
+          height: 100,
+          deliveryType
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+      // TODO: should library be adding a version to URLs?
+      expect(url).toContain(src.replace('/v1234', ''));
+    });
+
     it('should create a Cloudinary URL with custom quality and format options', () => {
       const format = 'png';
       const quality = 75;

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -54,4 +54,45 @@ describe('Cropping plugin', () => {
     plugin({ cldImage, options });
     expect(cldImage.toURL()).toContain(`image/upload/${TEST_PUBLIC_ID}`);
   });
+
+  it('should return resize override with original size in URL if resize is smaller than width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 900,
+      widthResize: 600
+    };
+
+    const { options: pluginOptions } = plugin({ cldImage, options });
+
+    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
+    expect(pluginOptions).toMatchObject({
+      width: options.widthResize
+    })
+  });
+
+  it('should not return resize override with original size in URL if resize is larger than width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 900,
+      widthResize: 1200
+    };
+
+    const { options: pluginOptions } = plugin({ cldImage, options });
+
+    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
+    expect(pluginOptions).toMatchObject({})
+  });
+
+  it('should not return resize override with original size in URL if resize is the same as width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 900,
+      widthResize: 900
+    };
+
+    const { options: pluginOptions } = plugin({ cldImage, options });
+
+    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
+    expect(pluginOptions).toMatchObject({})
+  });
 });


### PR DESCRIPTION
# Description

By default, when passing in a width, the URL generator returns a c_fill,w_[size] value based on the passed in width.

This generally works well to help define that value based on the width the caller wants, but if the raw transformations includes a value that conflicts with the size after, can create an error. This doesnt different from usual usage, but the expectation of how the props operate is that when you specify a width, you're going to specify dimensions and positioning relative to that

The example use case here is the Cloudinary Media Editor that may provide positioning and cropping based on the original image, which will create an issue if applied after this width.

## Issue Ticket Number

Fixes #24 
Original Issue: https://github.com/colbyfayock/next-cloudinary/issues/149

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
