### PR TITLE
Adds support for . in public ID

### DIFF
--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -182,6 +182,34 @@ describe('Cloudinary', () => {
         version,
       });
     });
+
+    it('should parse a Cloudinary URL with a . in the public ID', () => {
+      const assetType = 'images';
+      const cloudName = 'test-cloud';
+      const deliveryType = undefined;
+      const format = '.png';
+      const host = 'res.cloudinary.com';
+      const publicId = 'sticker-keepdevweird-2.5in-holographic';
+      const seoSuffix = 'sticker-keepdevweird-2.5in-holographic';
+      const signature = undefined;
+      const transformations = ['f_auto,q_auto'];
+      const version = 1234;
+
+      const src = `https://${host}/${cloudName}/${assetType}/${transformations.join('/')}/v${version}/${publicId}/${seoSuffix}${format}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        format,
+        host,
+        publicId,
+        seoSuffix,
+        signature,
+        transformations,
+        version,
+      });
+    });
   });
 
   describe('getPublicId', () => {


### PR DESCRIPTION
# Description

Previously parsing would fail with a `.` in a public ID

I wasn't sure how to solve this by changing the existing regex so I added an extra step to the parsing and first rip out the format if it exists, then continue on with the rest of the parsing.

Pulled all supported formats / extensions from cloudinary docs:

- https://cloudinary.com/documentation/image_transformations#image_format_support
- https://cloudinary.com/documentation/video_manipulation_and_delivery#supported_video_formats

## Issue Ticket Number

Fixes #26 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
