### PR TITLE
Color converter, ,./ encoding

### DIFF
--- a/packages/url-loader/src/constants/qualifiers.ts
+++ b/packages/url-loader/src/constants/qualifiers.ts
@@ -1,4 +1,12 @@
 import { Qualifier } from '../types/qualifiers';
+import { testColorIsHex, convertColorHexToRgb } from '../lib/colors';
+
+const convertersColors = [
+  {
+    test: testColorIsHex,
+    convert: convertColorHexToRgb
+  }
+]
 
 export const primary: Record<string, Qualifier> = {
   aspectRatio: {
@@ -47,7 +55,8 @@ export const text: Record<string, Qualifier> = {
   },
   color: {
     qualifier: 'co',
-    location: 'primary'
+    location: 'primary',
+    converters: convertersColors
   },
   fontFamily: {
     qualifier: false,
@@ -141,6 +150,7 @@ export const effects: Record<string, Qualifier> = {
   },
   color: {
     qualifier: 'co',
+    converters: convertersColors
   },
   colorize: {
     prefix: 'e',

--- a/packages/url-loader/src/index.ts
+++ b/packages/url-loader/src/index.ts
@@ -7,4 +7,4 @@ export type { ImageOptionsResize, ImageOptionsZoomPan, ImageOptions } from './ty
 export type { AnalyticsOptions } from './types/analytics';
 export type { ConfigOptions } from './types/config';
 export type { PluginSettings, PluginOverrides } from './types/plugins';
-export type { Qualifier } from './types/qualifiers';
+export type { Qualifier, QualiferConverters } from './types/qualifiers';

--- a/packages/url-loader/src/lib/colors.ts
+++ b/packages/url-loader/src/lib/colors.ts
@@ -1,0 +1,16 @@
+/**
+ * testColorIsHex
+ */
+
+export function testColorIsHex(value: any) {
+  if ( typeof value !== 'string' ) return false
+  return !!value.startsWith('#');
+}
+
+/**
+ * convertColorHexToRgb
+ */
+
+export function convertColorHexToRgb(value: string) {
+  return `rgb:${value.replace('#', '')}`;
+}

--- a/packages/url-loader/src/lib/transformations.ts
+++ b/packages/url-loader/src/lib/transformations.ts
@@ -1,3 +1,5 @@
+import { QualiferConverters } from "../types/qualifiers";
+
 /**
  * constructTransformation
  * @description Constructs a transformation string to append to a URL
@@ -8,24 +10,32 @@ interface ConstructTransformationSettings {
   prefix?: string;
   qualifier?: string | boolean;
   value?: string | boolean;
+  converters?: Array<QualiferConverters>;
 }
 
-export function constructTransformation({ prefix, qualifier, value }: ConstructTransformationSettings) {
+export function constructTransformation({ prefix, qualifier, value, converters }: ConstructTransformationSettings) {
   let transformation = '';
 
   if ( prefix ) {
     transformation = `${prefix}_`;
   }
 
-  if ( value === true || value === 'true' ) {
+  let transformationValue = value;
+
+  converters?.forEach(({ test, convert }) => {
+    if ( !test(transformationValue) ) return;
+    transformationValue = convert(transformationValue);
+  })
+
+  if ( transformationValue === true || transformationValue === 'true' ) {
     return `${transformation}${qualifier}`;
   }
 
-  if ( typeof value === 'string' || typeof value === 'number' ) {
+  if ( typeof transformationValue === 'string' || typeof transformationValue === 'number' ) {
     if ( prefix ) {
-      return `${transformation}${qualifier}:${value}`;
+      return `${transformation}${qualifier}:${transformationValue}`;
     } else {
-      return `${qualifier}_${value}`;
+      return `${qualifier}_${transformationValue}`;
     }
   }
 }

--- a/packages/url-loader/src/plugins/effects.ts
+++ b/packages/url-loader/src/plugins/effects.ts
@@ -37,11 +37,12 @@ export function plugin(props: PluginSettings) {
 
   function constructTransformationString({ effects, options }: ConstructTransformationStringSettings) {
     return (Object.keys(effects) as Array<keyof typeof effects>).map(key => {
-      const { prefix, qualifier } = effects[key];
+      const { prefix, qualifier, converters } = effects[key];
       return constructTransformation({
         qualifier,
         prefix,
-        value: options?.[key]
+        value: options?.[key],
+        converters
       });
     })
   }

--- a/packages/url-loader/src/types/qualifiers.ts
+++ b/packages/url-loader/src/types/qualifiers.ts
@@ -1,6 +1,12 @@
+export interface QualiferConverters {
+  test: Function;
+  convert: Function;
+}
+
 export interface Qualifier {
   location?: string;
   order?: number;
   prefix?: string;
   qualifier?: string | boolean;
+  converters?: Array<QualiferConverters>
 }

--- a/packages/url-loader/tests/plugins/effects.spec.js
+++ b/packages/url-loader/tests/plugins/effects.spec.js
@@ -61,4 +61,29 @@ describe('Plugins', () => {
 
     expect(cldImage.toURL()).toContain(`/o_${opacity},e_shear:${shear}/e_cartoonify:${cartoonify},e_gradient_fade,r_${radius}/`);
   });
+
+  it('should colorize with a hex color value', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+
+    const color = '#ff00ff';
+    const colorExpected = 'rgb:ff00ff';
+    const colorize = 50;
+
+
+    const options = {
+      effects: [
+        {
+          color,
+          colorize
+        },
+      ]
+    }
+
+    plugin({
+      cldImage,
+      options
+    });
+
+    expect(cldImage.toURL()).toContain(`/co_${colorExpected},e_colorize:${colorize}/`);
+  });
 });

--- a/packages/url-loader/tests/plugins/overlays.spec.js
+++ b/packages/url-loader/tests/plugins/overlays.spec.js
@@ -316,5 +316,53 @@ describe('Plugins', () => {
 
       expect(cldImage.toURL()).toContain(`l_text:${encodeURIComponent(fontFamily)}_${fontSize}_${fontWeight}_stroke:${encodeURIComponent(text)},co_${color},bo_${border}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
     });
+
+    it('should add text with special characters', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const color = 'white';
+      const fontFamily = 'Source Sans Pro';
+      const text = 'Ne xt/Cloud.in,ary';
+      const expectedText = 'Ne%20xt%252FCloud%252Ein%252Cary';
+
+      const options = {
+        text: {
+          color,
+          fontFamily,
+          text,
+        }
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_text:${encodeURIComponent(fontFamily)}_200_bold:${expectedText},co_${color}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
+    });
+
+    it('should replace color with #asdf with rgb:', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const color = '#ff00ff';
+      const expectedColor = 'rgb:ff00ff';
+      const fontFamily = 'Source Sans Pro';
+      const text = 'Next Cloudinary';
+
+      const options = {
+        text: {
+          color,
+          fontFamily,
+          text,
+        }
+      }
+
+      plugin({
+        cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_text:${encodeURIComponent(fontFamily)}_200_bold:${encodeURIComponent(text)},co_${expectedColor}/fl_layer_apply,fl_no_overflow/${TEST_PUBLIC_ID}`);
+    });
   });
 });


### PR DESCRIPTION
# Description

* Handles encoding special characters ,./ to avoid having to do it from the user side
* Creates a new concept of converters that allows qualifiers to transform values
* First use case is taking #color to rgb:color

## Issue Ticket Number

Fixes #34 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
