### PR TITLE
constructCloudinaryUrl Video Support

### DIFF
--- a/packages/url-loader/src/constants/assets.ts
+++ b/packages/url-loader/src/constants/assets.ts
@@ -1,0 +1,6 @@
+export const SUPPORTED_ASSET_TYPES = [
+  'image',
+  'images',
+  'video',
+  'videos',
+]

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -75,6 +75,10 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     throw Error(`Failed to construct Cloudinary URL: Missing source (src) in options`);
   }
 
+  if ( !options?.assetType ) {
+    options.assetType = 'image';
+  }
+
   const parsedOptions: Pick<ParseUrl, 'seoSuffix' | 'version'> = {
     seoSuffix: undefined,
     version: undefined,
@@ -109,11 +113,21 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
 
   // Begin creating a new Cloudinary image instance and configure
 
-  const cldImage = cld.image(publicId);
+  let cldAsset: any = undefined;
+
+  if ( ['image', 'images'].includes(options.assetType) ) {
+    cldAsset = cld.image(publicId);
+  } else if ( ['video', 'videos'].includes(options.assetType) ) {
+    cldAsset = cld.video(publicId);
+  }
+
+  if ( typeof cldAsset === 'undefined' ) {
+    throw new Error('Invalid asset type.');
+  }
 
   transformationPlugins.forEach(({ plugin }) => {
     const results: PluginResults = plugin({
-      cldImage,
+      cldAsset,
       options
     });
 
@@ -135,10 +149,10 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
 
   if ( options?.resize ) {
     const { width, crop = 'scale' } = options.resize;
-    cldImage.effect(`c_${crop},w_${width}`);
+    cldAsset.effect(`c_${crop},w_${width}`);
   }
 
-  return cldImage
+  return cldAsset
           .setDeliveryType(options?.deliveryType || 'upload')
           .format(options?.format || 'auto')
           .delivery(`q_${options?.quality || 'auto'}`)

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -125,7 +125,20 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     throw new Error('Invalid asset type.');
   }
 
-  transformationPlugins.forEach(({ plugin }) => {
+  transformationPlugins.forEach(({ plugin, assetTypes, props }) => {
+    const supportedAssetType = typeof options?.assetType !== 'undefined' && assetTypes.includes(options?.assetType);
+
+    if ( !supportedAssetType ) {
+      const optionsKeys = Object.keys(options);
+      const attemptedUse = props.map(prop => optionsKeys.includes(prop)).filter(isUsed => !!isUsed).length > 0;
+
+      if ( attemptedUse ) {
+        console.warn(`One of the following props [${props.join(', ')}] was used with an unsupported asset type [${options?.assetType}]`);
+      }
+
+      return;
+    }
+
     const results: PluginResults = plugin({
       cldAsset,
       options

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -8,6 +8,7 @@ export const props = [
   'gravity',
   'zoom'
 ];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 /**
  * normalizeNumberParameter

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -20,7 +20,7 @@ export function normalizeNumberParameter(param: number | string | undefined) {
 }
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
 
   const {
     width: defaultWidth,
@@ -85,7 +85,7 @@ export function plugin(props: PluginSettings) {
 
   // Finally apply the constructed transformation string to the image instance
 
-  cldImage.effect(transformationString);
+  cldAsset.effect(transformationString);
 
   // If we have a resize width that's smaller than the user-defined width, we want to give the
   // ability to perform a final resize on the image without impacting any of the effects like text

--- a/packages/url-loader/src/plugins/effects.ts
+++ b/packages/url-loader/src/plugins/effects.ts
@@ -4,6 +4,7 @@ import { effects as qualifiersEffects } from '../constants/qualifiers';
 import { constructTransformation } from '../lib/transformations';
 
 export const props = [...Object.keys(qualifiersEffects), 'effects'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/effects.ts
+++ b/packages/url-loader/src/plugins/effects.ts
@@ -6,7 +6,7 @@ import { constructTransformation } from '../lib/transformations';
 export const props = [...Object.keys(qualifiersEffects), 'effects'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
 
   // Handle any top-level effect props
 
@@ -15,7 +15,7 @@ export function plugin(props: PluginSettings) {
     options
   })
 
-  transformationStrings.filter(t => !!t).forEach(transformation => cldImage.effect(transformation));;
+  transformationStrings.filter(t => !!t).forEach(transformation => cldAsset.effect(transformation));;
 
   // If we're passing in an effects prop explicitly, treat it as an array of
   // effects that we need to process
@@ -26,7 +26,7 @@ export function plugin(props: PluginSettings) {
         effects: qualifiersEffects,
         options: effectsSet
       }).filter(t => !!t).join(',');
-      cldImage.effect(transformationString);
+      cldAsset.effect(transformationString);
     });
   }
 

--- a/packages/url-loader/src/plugins/named-transformations.ts
+++ b/packages/url-loader/src/plugins/named-transformations.ts
@@ -1,6 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['transformations'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/named-transformations.ts
+++ b/packages/url-loader/src/plugins/named-transformations.ts
@@ -3,7 +3,7 @@ import { PluginSettings } from '../types/plugins';
 export const props = ['transformations'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   let { transformations = [] } = options;
 
   if ( !Array.isArray(transformations) ) {
@@ -11,7 +11,7 @@ export function plugin(props: PluginSettings) {
   }
 
   transformations.forEach(transformation => {
-    cldImage.addTransformation(`t_${transformation}`);
+    cldAsset.addTransformation(`t_${transformation}`);
   });
 
   return {};

--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -22,7 +22,7 @@ export const DEFAULT_TEXT_OPTIONS = {
 };
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { text, overlays = [] } = options;
 
   const type = 'overlay';
@@ -267,7 +267,7 @@ export function plugin(props: PluginSettings) {
 
     // Finally add it to the image
 
-    cldImage.addTransformation(layerTransformation);
+    cldAsset.addTransformation(layerTransformation);
   }
 
   return {};

--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -13,6 +13,7 @@ import {
 } from '../constants/qualifiers';
 
 export const props = ['text', 'overlays'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export const DEFAULT_TEXT_OPTIONS = {
   color: 'black',

--- a/packages/url-loader/src/plugins/raw-transformations.ts
+++ b/packages/url-loader/src/plugins/raw-transformations.ts
@@ -3,11 +3,11 @@ import { PluginSettings } from '../types/plugins';
 export const props = ['rawTransformations'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { rawTransformations = [] } = options;
 
   rawTransformations.forEach(transformation => {
-    cldImage.addTransformation(transformation);
+    cldAsset.addTransformation(transformation);
   });
 
   return {};

--- a/packages/url-loader/src/plugins/raw-transformations.ts
+++ b/packages/url-loader/src/plugins/raw-transformations.ts
@@ -1,6 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['rawTransformations'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/remove-background.ts
+++ b/packages/url-loader/src/plugins/remove-background.ts
@@ -3,10 +3,10 @@ import { PluginSettings } from '../types/plugins';
 export const props = ['removeBackground'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { removeBackground = false } = options;
   if ( removeBackground ) {
-    cldImage.effect('e_background_removal');
+    cldAsset.effect('e_background_removal');
   }
   return {};
 }

--- a/packages/url-loader/src/plugins/remove-background.ts
+++ b/packages/url-loader/src/plugins/remove-background.ts
@@ -1,6 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['removeBackground'];
+export const assetTypes = ['image', 'images'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/sanitize.ts
+++ b/packages/url-loader/src/plugins/sanitize.ts
@@ -3,15 +3,15 @@ import { PluginSettings } from '../types/plugins';
 export const props = ['sanitize'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { sanitize = true } = options;
 
   const shouldApplySanitizer: boolean =
     sanitize &&
-    (options.format === 'svg' || cldImage.publicID.endsWith('.svg'));
+    (options.format === 'svg' || cldAsset.publicID.endsWith('.svg'));
 
   if (shouldApplySanitizer) {
-    cldImage.effect('fl_sanitize');
+    cldAsset.effect('fl_sanitize');
   }
 
   return {};

--- a/packages/url-loader/src/plugins/sanitize.ts
+++ b/packages/url-loader/src/plugins/sanitize.ts
@@ -1,6 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['sanitize'];
+export const assetTypes = ['image', 'images'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/seo.ts
+++ b/packages/url-loader/src/plugins/seo.ts
@@ -5,14 +5,14 @@ export const props = [
 ];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { seoSuffix } = options;
 
   if ( typeof seoSuffix === 'string' ) {
     if ( options.deliveryType === 'fetch' ) {
       console.warn('SEO suffix is not supported with a delivery type of fetch')
     } else {
-      cldImage.setSuffix(seoSuffix);
+      cldAsset.setSuffix(seoSuffix);
     }
   }
 

--- a/packages/url-loader/src/plugins/seo.ts
+++ b/packages/url-loader/src/plugins/seo.ts
@@ -1,8 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
-export const props = [
-  'seoSuffix'
-];
+export const props = ['seoSuffix'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/underlays.ts
+++ b/packages/url-loader/src/plugins/underlays.ts
@@ -9,6 +9,7 @@ import {
 } from '../constants/qualifiers';
 
 export const props = ['underlay', 'underlays'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/underlays.ts
+++ b/packages/url-loader/src/plugins/underlays.ts
@@ -11,7 +11,7 @@ import {
 export const props = ['underlay', 'underlays'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { underlay, underlays = [] } = options;
 
   const typeQualifier = 'u';
@@ -118,7 +118,7 @@ export function plugin(props: PluginSettings) {
 
     // Finally add it to the image
 
-    cldImage.addTransformation(layerTransformation);
+    cldAsset.addTransformation(layerTransformation);
   }
 
   return {};

--- a/packages/url-loader/src/plugins/version.ts
+++ b/packages/url-loader/src/plugins/version.ts
@@ -3,13 +3,13 @@ import { PluginSettings } from '../types/plugins';
 export const props = ['version'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { version } = options;
 
   if ( typeof version === 'string' || typeof version === 'number' ) {
     // Replace a `v` in the string just in case the caller
     // passes it in
-    cldImage.setVersion(`${version}`.replace('v', ''));
+    cldAsset.setVersion(`${version}`.replace('v', ''));
   }
 
   return {};

--- a/packages/url-loader/src/plugins/version.ts
+++ b/packages/url-loader/src/plugins/version.ts
@@ -1,6 +1,7 @@
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['version'];
+export const assetTypes = ['image', 'images', 'video', 'videos'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -1,6 +1,7 @@
 import { PluginSettings, PluginOverrides } from '../types/plugins';
 
 export const props = ['zoompan'];
+export const assetTypes = ['image', 'images'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -3,7 +3,7 @@ import { PluginSettings, PluginOverrides } from '../types/plugins';
 export const props = ['zoompan'];
 
 export function plugin(props: PluginSettings) {
-  const { cldImage, options } = props;
+  const { cldAsset, options } = props;
   const { zoompan = false } = options;
 
   const overrides: PluginOverrides = {
@@ -11,13 +11,13 @@ export function plugin(props: PluginSettings) {
   };
 
   if ( zoompan === true ) {
-    cldImage.effect('e_zoompan');
+    cldAsset.effect('e_zoompan');
   } else if ( typeof zoompan === 'string' ) {
     if ( zoompan === 'loop' ) {
-      cldImage.effect('e_zoompan');
-      cldImage.effect('e_loop');
+      cldAsset.effect('e_zoompan');
+      cldAsset.effect('e_loop');
     } else {
-      cldImage.effect(`e_zoompan:${zoompan}`);
+      cldAsset.effect(`e_zoompan:${zoompan}`);
     }
   } else if ( typeof zoompan === 'object' ) {
     let zoompanEffect = 'e_zoompan';
@@ -26,7 +26,7 @@ export function plugin(props: PluginSettings) {
       zoompanEffect = `${zoompanEffect}${zoompan.options}`;
     }
 
-    cldImage.effect(zoompanEffect);
+    cldAsset.effect(zoompanEffect);
 
     let loopEffect;
 
@@ -37,7 +37,7 @@ export function plugin(props: PluginSettings) {
     }
 
     if ( loopEffect ) {
-      cldImage.effect(loopEffect);
+      cldAsset.effect(loopEffect);
     }
   }
 

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -1,7 +1,7 @@
 import { ImageOptions } from './image';
 
 export interface PluginSettings {
-  cldImage: any;
+  cldAsset: any;
   options: ImageOptions;
 }
 

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -14,7 +14,7 @@ describe('Cloudinary', () => {
 
   describe('constructCloudinaryUrl', () => {
 
-    it('should create a Cloudinary URL', () => {
+    it('should create a Cloudinary image URL', () => {
       const cloudName = 'customtestcloud';
       const url = constructCloudinaryUrl({
         options: {
@@ -29,6 +29,25 @@ describe('Cloudinary', () => {
         }
       });
       expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_auto/q_auto/turtle`);
+    });
+
+    it('should create a Cloudinary video URL', () => {
+      const cloudName = 'customtestcloud';
+      const assetType = 'video';
+      const url = constructCloudinaryUrl({
+        options: {
+          assetType,
+          src: 'turtle',
+          width: 100,
+          height: 100
+        },
+        config: {
+          cloud: {
+            cloudName
+          }
+        }
+      });
+      expect(url).toContain(`https://res.cloudinary.com/${cloudName}/${assetType}/upload/c_limit,w_100/f_auto/q_auto/turtle`);
     });
 
     /* Optimization */

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -312,6 +312,32 @@ describe('Cloudinary', () => {
 
     })
 
+    /* General Plugins */
+
+    describe('Plugins', () => {
+
+      it('should not apply an image-only plugin to a video asset', () => {
+        const cloudName = 'customtestcloud';
+        const assetType = 'video';
+        const src = 'turtle';
+        const zoompan = 'loop';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            assetType,
+            zoompan
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`${assetType}/upload/f_auto/q_auto/${src}`);
+      });
+
+    })
+
 
   });
 });

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -21,7 +21,7 @@ describe('Cropping plugin', () => {
       crop: 'crop',
       gravity: 'auto'
     };
-    plugin({ cldImage, options });
+    plugin({ cldAsset: cldImage, options });
     expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_${options.gravity}/${TEST_PUBLIC_ID}`);
   });
 
@@ -32,7 +32,7 @@ describe('Cropping plugin', () => {
       height: 100,
       crop: 'fill'
     };
-    plugin({ cldImage, options });
+    plugin({ cldAsset: cldImage, options });
     expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto/${TEST_PUBLIC_ID}`);
   });
 
@@ -44,14 +44,14 @@ describe('Cropping plugin', () => {
       crop: 'fill',
       zoom: 0.5
     };
-    plugin({ cldImage, options });
+    plugin({ cldAsset: cldImage, options });
     expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}/${TEST_PUBLIC_ID}`);
   });
 
   it('should not include a width if not set', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);
     const options = {};
-    plugin({ cldImage, options });
+    plugin({ cldAsset: cldImage, options });
     expect(cldImage.toURL()).toContain(`image/upload/${TEST_PUBLIC_ID}`);
   });
 
@@ -62,7 +62,7 @@ describe('Cropping plugin', () => {
       widthResize: 600
     };
 
-    const { options: pluginOptions } = plugin({ cldImage, options });
+    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
 
     expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
     expect(pluginOptions).toMatchObject({
@@ -77,7 +77,7 @@ describe('Cropping plugin', () => {
       widthResize: 1200
     };
 
-    const { options: pluginOptions } = plugin({ cldImage, options });
+    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
 
     expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
     expect(pluginOptions).toMatchObject({})
@@ -90,7 +90,7 @@ describe('Cropping plugin', () => {
       widthResize: 900
     };
 
-    const { options: pluginOptions } = plugin({ cldImage, options });
+    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
 
     expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
     expect(pluginOptions).toMatchObject({})

--- a/packages/url-loader/tests/plugins/effects.spec.js
+++ b/packages/url-loader/tests/plugins/effects.spec.js
@@ -25,7 +25,7 @@ describe('Plugins', () => {
     }
 
     plugin({
-      cldImage,
+      cldAsset: cldImage,
       options
     });
 
@@ -55,7 +55,7 @@ describe('Plugins', () => {
     }
 
     plugin({
-      cldImage,
+      cldAsset: cldImage,
       options
     });
 
@@ -80,7 +80,7 @@ describe('Plugins', () => {
     }
 
     plugin({
-      cldImage,
+      cldAsset: cldImage,
       options
     });
 

--- a/packages/url-loader/tests/plugins/named-transformations.spec.js
+++ b/packages/url-loader/tests/plugins/named-transformations.spec.js
@@ -23,7 +23,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -42,7 +42,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 

--- a/packages/url-loader/tests/plugins/overlays.spec.js
+++ b/packages/url-loader/tests/plugins/overlays.spec.js
@@ -25,7 +25,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -44,7 +44,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -77,7 +77,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -109,7 +109,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -136,7 +136,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -166,7 +166,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -187,7 +187,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -205,7 +205,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -236,7 +236,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -279,7 +279,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -310,7 +310,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -334,7 +334,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -358,7 +358,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 

--- a/packages/url-loader/tests/plugins/raw-transformations.spec.js
+++ b/packages/url-loader/tests/plugins/raw-transformations.spec.js
@@ -25,7 +25,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -44,7 +44,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 

--- a/packages/url-loader/tests/plugins/sanitize.spec.ts
+++ b/packages/url-loader/tests/plugins/sanitize.spec.ts
@@ -15,7 +15,7 @@ describe('Cloudinary Sanitize', () => {
     it('should include fl_sanitize when display image source name end with svg', () => {
       const src = 'turtle.svg';
       const cldImage = cld.image(src);
-      plugin({ cldImage, options: {
+      plugin({ cldAsset: cldImage, options: {
         src
       } });
       expect(cldImage.toURL()).toContain(`image/upload/fl_sanitize/turtle.svg`);
@@ -24,7 +24,7 @@ describe('Cloudinary Sanitize', () => {
     it('should include fl_sanitize and f_svg when display format is svg', () => {
       const src = 'turtle';
       const cldImage = cld.image(src);
-      plugin({ cldImage, options: {
+      plugin({ cldAsset: cldImage, options: {
         format: 'svg',
         src
       } });
@@ -34,7 +34,7 @@ describe('Cloudinary Sanitize', () => {
     it('should include fl_sanitize and f_svg when display format svg image', () => {
       const src = 'turtle.svg';
       const cldImage = cld.image(src);
-      plugin({ cldImage, options: {
+      plugin({ cldAsset: cldImage, options: {
         format: 'svg',
         src
       } });
@@ -44,7 +44,7 @@ describe('Cloudinary Sanitize', () => {
     it('should not include fl_sanitize when set option sanitize to false', () => {
       const src = 'turtle.svg';
       const cldImage = cld.image(src);
-      plugin({ cldImage, options: {
+      plugin({ cldAsset: cldImage, options: {
         sanitize: false,
         src
       } });
@@ -54,7 +54,7 @@ describe('Cloudinary Sanitize', () => {
     it('should not include fl_sanitize when display other image', () => {
       const src = 'turtle';
       const cldImage = cld.image(src);
-      plugin({ cldImage, options: {
+      plugin({ cldAsset: cldImage, options: {
         src
       } });
       expect(cldImage.toURL()).toContain(`image/upload/turtle`);

--- a/packages/url-loader/tests/plugins/underlays.spec.js
+++ b/packages/url-loader/tests/plugins/underlays.spec.js
@@ -32,7 +32,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 
@@ -52,7 +52,7 @@ describe('Plugins', () => {
       }
 
       plugin({
-        cldImage,
+        cldAsset: cldImage,
         options
       });
 


### PR DESCRIPTION
# Description

* Sets up the construct URL function to support videos
* Updates the code to `cldAsset` instead of `cldImage` for an ambiguous term
* Setting up supported types for plugins to avoid unnecessary transformations

## Issue Ticket Number

Fixes #6 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
