### PR TITLE
Video Types, Streaming Profile

### DIFF
--- a/packages/url-loader/src/constants/qualifiers.ts
+++ b/packages/url-loader/src/constants/qualifiers.ts
@@ -291,3 +291,10 @@ export const flags: Record<string, Qualifier> = {
     location: 'primary'
   }
 } as const;
+
+export const video: Record<string, Qualifier> = {
+  streamingProfile: {
+    qualifier: 'sp',
+    location: 'primary'
+  }
+} as const;

--- a/packages/url-loader/src/index.ts
+++ b/packages/url-loader/src/index.ts
@@ -3,7 +3,10 @@ export type { ConstructUrlProps, PluginOptionsResize, PluginOptions, PluginResul
 
 export { effects, position, primary, text } from './constants/qualifiers';
 
+export type { AssetOptionsResize, AssetOptions } from './types/asset';
 export type { ImageOptionsResize, ImageOptionsZoomPan, ImageOptions } from './types/image';
+export type { VideoOptionsResize, VideoOptions } from './types/video';
+
 export type { AnalyticsOptions } from './types/analytics';
 export type { ConfigOptions } from './types/config';
 export type { PluginSettings, PluginOverrides } from './types/plugins';

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -11,6 +11,7 @@ import * as removeBackgroundPlugin from '../plugins/remove-background';
 import * as seoPlugin from '../plugins/seo';
 import * as underlaysPlugin from '../plugins/underlays';
 import * as versionPlugin from '../plugins/version';
+import * as videoPlugin from '../plugins/video';
 import * as zoompanPlugin from '../plugins/zoompan';
 
 import { ImageOptions } from '../types/image';
@@ -36,6 +37,7 @@ export const transformationPlugins = [
   seoPlugin,
   underlaysPlugin,
   versionPlugin,
+  videoPlugin,
   zoompanPlugin,
 ];
 

--- a/packages/url-loader/src/plugins/video.ts
+++ b/packages/url-loader/src/plugins/video.ts
@@ -1,0 +1,30 @@
+import { objectHasKey } from '@cloudinary-util/util';
+
+import { PluginSettings } from '../types/plugins';
+
+import { video as qualifiersVideo } from '../constants/qualifiers';
+import { constructTransformation } from '../lib/transformations';
+
+export const props = [...Object.keys(qualifiersVideo), 'effects'];
+export const assetTypes = ['video', 'videos'];
+
+export function plugin(props: PluginSettings) {
+  const { cldAsset, options } = props;
+
+  (Object.keys(options) as Array<keyof typeof options>).forEach(key => {
+    if ( !objectHasKey(qualifiersVideo, key) ) return;
+
+    const { prefix, qualifier, converters } = qualifiersVideo[key];
+
+    const transformation = constructTransformation({
+      prefix,
+      qualifier,
+      value: options[key],
+      converters
+    });
+
+    cldAsset.addTransformation(transformation);
+  });
+
+  return {};
+}

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -1,3 +1,4 @@
+import { ImageOptions } from '../types/image';
 import { PluginSettings, PluginOverrides } from '../types/plugins';
 
 export const props = ['zoompan'];
@@ -5,7 +6,7 @@ export const assetTypes = ['image', 'images'];
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
-  const { zoompan = false } = options;
+  const { zoompan = false } = options as ImageOptions; // why do i need to cast it here?
 
   const overrides: PluginOverrides = {
     format: undefined

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -1,0 +1,30 @@
+export interface AssetOptionsResize {
+  crop?: string;
+  width?: number | string;
+}
+
+export interface AssetOptions {
+  assetType?: string;
+  crop?: string;
+  deliveryType?: string;
+  effects?: Array<any>;
+  format?: string;
+  gravity?: string;
+  height?: string | number;
+  overlays?: Array<any>;
+  quality?: number;
+  rawTransformations?: string[];
+  removeBackground?: boolean;
+  sanitize?: boolean;
+  resize?: AssetOptionsResize;
+  seoSuffix?: string;
+  src: string;
+  text?: any;
+  transformations?: Array<string>;
+  underlay?: string;
+  underlays?: Array<any>;
+  version?: number | string;
+  width?: string | number;
+  widthResize?: string | number;
+  zoom?: string;
+}

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -1,35 +1,12 @@
-export interface ImageOptionsResize {
-  crop?: string;
-  width?: number | string;
-}
+import type { AssetOptions, AssetOptionsResize } from './asset';
+
+export interface ImageOptionsResize extends AssetOptionsResize {}
+
 export interface ImageOptionsZoomPan {
   loop: string | boolean;
   options: string;
 }
 
-export interface ImageOptions {
-  assetType?: string;
-  crop?: string;
-  deliveryType?: string;
-  effects?: Array<any>;
-  format?: string;
-  gravity?: string;
-  height?: string | number;
-  overlays?: Array<any>;
-  quality?: number;
-  rawTransformations?: string[];
-  removeBackground?: boolean;
-  sanitize?: boolean;
-  resize?: ImageOptionsResize;
-  seoSuffix?: string;
-  src: string;
-  text?: any;
-  transformations?: Array<string>;
-  underlay?: string;
-  underlays?: Array<any>;
-  version?: number | string;
-  width?: string | number;
-  widthResize?: string | number;
-  zoom?: string;
+export interface ImageOptions extends AssetOptions {
   zoompan?: string | boolean | ImageOptionsZoomPan;
 }

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -1,8 +1,10 @@
+import { AssetOptions } from './asset';
 import { ImageOptions } from './image';
+import { VideoOptions } from './video';
 
 export interface PluginSettings {
   cldAsset: any;
-  options: ImageOptions;
+  options: AssetOptions | ImageOptions | VideoOptions;
 }
 
 export interface PluginOverrides {

--- a/packages/url-loader/src/types/video.ts
+++ b/packages/url-loader/src/types/video.ts
@@ -1,0 +1,7 @@
+import type { AssetOptions, AssetOptionsResize } from './asset';
+
+export interface VideoOptionsResize extends AssetOptionsResize {}
+
+export interface VideoOptions extends AssetOptions {
+  streamingProfile?: string;
+}

--- a/packages/url-loader/tests/plugins/video.spec.js
+++ b/packages/url-loader/tests/plugins/video.spec.js
@@ -1,0 +1,39 @@
+import { Cloudinary } from '@cloudinary/url-gen';
+
+import * as videoPlugin from '../../src/plugins/video';
+
+const { plugin } = videoPlugin
+
+const cld = new Cloudinary({
+  cloud: {
+    cloudName: 'test-cloud-name'
+  }
+});
+
+describe('Plugins', () => {
+  describe('Video', () => {
+    it('should include sp_auto on a video with streamingProfile of auto', () => {
+      const src = 'turtle.mp4';
+      const cldVideo = cld.video(src);
+      const streamingProfile = 'auto';
+      plugin({ cldAsset: cldVideo, options: {
+        assetType: 'video',
+        src,
+        streamingProfile
+      } });
+      expect(cldVideo.toURL()).toContain(`video/upload/sp_${streamingProfile}/${src}`);
+    }); 
+
+    it('should include streamingProfile with subtitles', () => {
+      const src = 'turtle.mp4';
+      const streamingProfile = 'sd:subtitles_((code_en-US;file_outdoors.vtt);(code_es-ES;file_outdoors-es.vtt))';
+      const cldVideo = cld.video(src);
+      plugin({ cldAsset: cldVideo, options: {
+        assetType: 'video',
+        src,
+        streamingProfile
+      } });
+      expect(cldVideo.toURL()).toContain(`video/upload/sp_${streamingProfile}/${src}`);
+    }); 
+  });
+});


### PR DESCRIPTION
# Description

Adds support for Streaming Profile via `sp_` including `sp_auto`

https://cloudinary.com/documentation/adaptive_bitrate_streaming#automatic_streaming_profile_selection

Additionally sets up video types to distinguish options

## Issue Ticket Number

Fixes #39 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
