### PR TITLE
Duplicate Props Does Not Throw Error - Effects Exists Twice

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -81,6 +81,17 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     options.assetType = 'image';
   }
 
+  const propsCheck: Array<string> = [];
+
+  transformationPlugins.forEach(({ props = [] }) => {
+    props.forEach(prop => {
+      if ( propsCheck.includes(prop) ) {
+        throw new Error(`Option ${prop} already exists!`);
+      }
+      propsCheck.push(prop);
+    });
+  })
+
   const parsedOptions: Pick<ParseUrl, 'seoSuffix' | 'version'> = {
     seoSuffix: undefined,
     version: undefined,

--- a/packages/url-loader/src/plugins/video.ts
+++ b/packages/url-loader/src/plugins/video.ts
@@ -5,7 +5,7 @@ import { PluginSettings } from '../types/plugins';
 import { video as qualifiersVideo } from '../constants/qualifiers';
 import { constructTransformation } from '../lib/transformations';
 
-export const props = [...Object.keys(qualifiersVideo), 'effects'];
+export const props = [...Object.keys(qualifiersVideo)];
 export const assetTypes = ['video', 'videos'];
 
 export function plugin(props: PluginSettings) {

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -338,6 +338,42 @@ describe('Cloudinary', () => {
 
     })
 
+    /* Effects */
+
+    it('should apply effects by array', () => {
+      const cloudName = 'customtestcloud';
+        const assetType = 'video';
+        const src = 'turtle';
+        const shear = '40:0';
+        const gradientFade = true;
+        const opacity = '50';
+        const cartoonify = '50';
+        const radius = '150';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            assetType,
+            effects: [
+              {
+                shear,
+                opacity,
+              },
+              {
+                gradientFade,
+                cartoonify,
+                radius
+              }
+            ]
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`${assetType}/upload/o_${opacity},e_shear:${shear}/e_cartoonify:${cartoonify},e_gradient_fade,r_${radius}/f_auto/q_auto/${src}`);
+    });
+
 
   });
 });


### PR DESCRIPTION
# Description

`effects` was left in the video plugin file producing an error upstream

Next Cloudinary had a check for duplicate props but this library didn't

This fixes the duplicate effects but also adds the duplicate prop check and an effects test

## Issue Ticket Number

Fixes #41 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
