### PR TITLE
"default" turns off format and quality

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -180,11 +180,17 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
     cldAsset.effect(`c_${crop},w_${width}`);
   }
 
-  return cldAsset
-          .setDeliveryType(options?.deliveryType || 'upload')
-          .format(options?.format || 'auto')
-          .delivery(`q_${options?.quality || 'auto'}`)
-          .toURL({
-            trackedAnalytics: analytics
-          });
+  cldAsset.setDeliveryType(options?.deliveryType || 'upload');
+
+  if ( options?.format !== 'default' ) {
+    cldAsset.format(options?.format || 'auto')
+  }
+
+  if ( options?.quality !== 'default' ) {
+    cldAsset.quality(options?.quality || 'auto')
+  }
+
+  return cldAsset.toURL({
+    trackedAnalytics: analytics
+  });
 }

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -13,7 +13,7 @@ export interface AssetOptions {
   gravity?: string;
   height?: string | number;
   overlays?: Array<any>;
-  quality?: number;
+  quality?: number | string;
   rawTransformations?: string[];
   removeBackground?: boolean;
   sanitize?: boolean;

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -75,6 +75,31 @@ describe('Cloudinary', () => {
         expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/upload/c_limit,w_100/f_${format}/q_${quality}/turtle`);
       });
 
+      it('should not include quality or format in URL', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'upload';
+        const publicId = 'myimage';
+
+        const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/v1234/${publicId}?_a=B`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            width: 100,
+            height: 100,
+            quality: 'default',
+            format: 'default'
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(src);
+      });
+
     });
 
     /* Delivery */
@@ -124,7 +149,6 @@ describe('Cloudinary', () => {
 
         expect(url).toContain(src);
       });
-
     })
 
     /* SEO */


### PR DESCRIPTION
# Description

Certain flags do not allow the inclusion of quality of auto.

To help get around this and rather than forcing an arbitrary value, this adds the ability to turn off quality and format by passing in the  value of `default` 

## Issue Ticket Number

Fixes #46 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
