### PR TITLE
 Auto Generate Docs with Zod

### DIFF
--- a/packages/url-loader/src/plugins/fill-background.ts
+++ b/packages/url-loader/src/plugins/fill-background.ts
@@ -1,8 +1,23 @@
+import { z } from 'zod';
+
 import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
-export const props = ['fillBackground'];
-export const assetTypes = ['image', 'images'];
+// import { constructPluginSchema } from '../lib/plugins';
+
+const pluginProps = [
+  {
+    name: 'fillBackground',
+    type: z.boolean().optional(),
+    assetTypes: ['image', 'images']
+  }
+];
+
+// @todo
+// const pluginPropsSchema = constructPluginSchema(pluginProps);
+
+export const props = pluginProps.map(({ name }) => name);
+export const assetTypes = Array.from(new Set(pluginProps.flatMap(({ assetTypes }) => assetTypes)));
 
 const defaultCrop = 'pad';
 

--- a/packages/url-loader/src/plugins/flags.ts
+++ b/packages/url-loader/src/plugins/flags.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { PluginSettings } from '../types/plugins';
 
-import { constructPluginSchema } from '../lib/plugins';
+// import { constructPluginSchema } from '../lib/plugins';
 import { flags as qualifiersFlags } from '../constants/qualifiers';
 
 const pluginProps = [
@@ -16,7 +16,8 @@ const pluginProps = [
   }
 ];
 
-const pluginPropsSchema = constructPluginSchema(pluginProps);
+// @todo
+// const pluginPropsSchema = constructPluginSchema(pluginProps);
 
 export const props = pluginProps.map(({ name }) => name);
 export const assetTypes = Array.from(new Set(pluginProps.flatMap(({ assetTypes }) => assetTypes)));
@@ -27,8 +28,9 @@ export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
   const { flags = [] } = options;
 
-  const test = pluginPropsSchema.parse(options);
-  console.log('test', test)
+  // @todo
+  // const test = pluginPropsSchema.parse(options);
+  // console.log('test', test)
 
   // First iteration of adding flags follows the same pattern
   // as the top level option from Cloudinary URL Gen SDK where


### PR DESCRIPTION
# Description

Starts work of migrating project to Zod allowing the ability ot use runtime Types to automatically generate documentation.

The hope is this can be used for Cloudinary Util docs as well as repurposing it for framework docs automations.

## Issue Ticket Number

Fixes #50 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
