### PR TITLE
Decode Public ID to avoid double encoding

### DIFF
--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -173,6 +173,28 @@ describe('Cloudinary', () => {
 
         expect(url).toContain(`https://${src}`);
       });
+
+      it('should create a Cloudinary URL from a Cloudinary source with existing URL encoding', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'upload';
+        const publicId = 'my%20pug%20v2';
+
+        const src = `res.cloudinary.com/${cloudName}/image/${deliveryType}/f_auto/q_auto/v1234/${publicId}?_a=B`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: `http://${src}`,
+            deliveryType
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(`https://${src}`);
+      });
     })
 
     /* SEO */

--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -77,6 +77,14 @@ export function parseUrl(src: string): ParseUrl | undefined {
     parts.publicId = publicIdParts.join('/');
   }
 
+  // The URL Gen SDK which this library relies on will re-encode the public ID. To avoid issues where
+  // someone is already passing in a URL or ID that's been encoded programmatically, first decode
+  // the public ID, which should theoretically be harmless since it ends up getting encoded
+
+  if ( parts.publicId ) {
+    parts.publicId = decodeURIComponent(parts.publicId);
+  }
+
   return parts;
 }
 


### PR DESCRIPTION
# Description

Decodes the Public ID to avoid double encoding after passing in to the URL Gen SDK, which encodes the value itself.

## Issue Ticket Number

Fixes #59 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
