### PR TITLE
Adding -_ and 32-length support for signature

### DIFF
--- a/packages/util/src/lib/cloudinary.ts
+++ b/packages/util/src/lib/cloudinary.ts
@@ -1,6 +1,6 @@
 const REGEX_VERSION = /\/v\d+\//;
 const REGEX_FORMAT = /\.(ai|avif|gif|png|webp|bmp|bw|djvu|dng|ps|ept|eps|eps3|fbx|flif|gif|glb|gltf|heif|heic|ico|indd|jpg|jpe|jpeg|jp2|wdp|jxr|hdp|obj|pdf|ply|png|psd|arw|cr2|svg|tga|tif|tiff|u3ma|usdz|webp|3g2|3gp|avi|flv|m3u8|ts|m2ts|mts|mov|mkv|mp4|mpeg|mpd|mxf|ogv|webm|wmv)$/i
-const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s\-\-[a-zA-Z0-9]+\-\-)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<publicId>[^\s]+)$/;
+const REGEX_URL = /https?:\/\/(?<host>[^\/]+)\/(?<cloudName>[^\/]+)\/(?<assetType>image|images|video|videos|raw|files)\/(?<deliveryType>upload|fetch|private|authenticated|sprite|facebook|twitter|youtube|vimeo)?\/?(?<signature>s--([a-zA-Z0-9\_\-]{8}|[a-zA-Z0-9\_\-]{32})--)?\/?(?<transformations>(?:[^_\/]+_[^,\/]+,?\/?)*\/)*(?<version>v\d+|\w{1,2})\/(?<publicId>[^\s]+)$/;
 const ASSET_TYPES_SEO = ['images', 'videos', 'files'];
 
 

--- a/packages/util/tests/lib/cloudinary.spec.js
+++ b/packages/util/tests/lib/cloudinary.spec.js
@@ -71,6 +71,58 @@ describe('Cloudinary', () => {
       });
     });
 
+    it('should parse a Cloudinary URL with a signature that has special characters', () => {
+      const assetType = 'image';
+      const cloudName = 'test-cloud';
+      const deliveryType = 'fetch';
+      const format = undefined;
+      const host = 'res.cloudinary.com';
+      const publicId = 'images/turtle';
+      const signature = 's--abc-_123--';
+      const transformations = ['c_limit,w_960'];
+      const version = 1234;
+
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/v${version}/${publicId}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        format,
+        host,
+        publicId,
+        signature,
+        transformations,
+        version,
+      });
+    });
+
+    it('should parse a Cloudinary URL with a signature that has 32 characters', () => {
+      const assetType = 'image';
+      const cloudName = 'test-cloud';
+      const deliveryType = 'fetch';
+      const format = undefined;
+      const host = 'res.cloudinary.com';
+      const publicId = 'images/turtle';
+      const signature = 's--abcdefghij0123456789abcde01234_---';
+      const transformations = ['c_limit,w_960'];
+      const version = 1234;
+
+      const src = `https://${host}/${cloudName}/${assetType}/${deliveryType}/${signature}/${transformations.join('/')}/v${version}/${publicId}`;
+
+      expect(parseUrl(src)).toMatchObject({
+        assetType,
+        cloudName,
+        deliveryType,
+        format,
+        host,
+        publicId,
+        signature,
+        transformations,
+        version,
+      });
+    });
+
     it('should parse a video Cloudinary URL with deeply nested folders', () => {
       const assetType = 'video';
       const cloudName = 'test-cloud';


### PR DESCRIPTION
# Description

- Adds `-_` cahracter support to signature
- Restricts signature to predefined lengths 8 or 32 per spec

## Issue Ticket Number

Fixes #58 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
