### PR TITLE
DPR 

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -180,6 +180,14 @@ export function constructCloudinaryUrl({ options, config, analytics }: Construct
 
   cldAsset.setDeliveryType(options?.deliveryType || 'upload');
 
+  if ( options?.dpr ) {
+    let dpr = options.dpr;
+    if ( typeof dpr === 'number' ) {
+      dpr = dpr.toFixed(1);
+    }
+    cldAsset.addTransformation(`dpr_${dpr}`)
+  }
+
   if ( options?.format !== 'default' ) {
     cldAsset.format(options?.format || 'auto')
   }

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -7,6 +7,7 @@ export interface AssetOptions {
   assetType?: string;
   crop?: string;
   deliveryType?: string;
+  dpr?: number | string;
   effects?: Array<any>;
   flags?: Array<string> | object;
   format?: string;

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -52,7 +52,7 @@ describe('Cloudinary', () => {
 
     /* Optimization */
 
-    describe('format, quality', () => {
+    describe('format, quality, dpr', () => {
 
       it('should create a Cloudinary URL with custom quality and format options', () => {
         const format = 'png';
@@ -89,6 +89,80 @@ describe('Cloudinary', () => {
             height: 100,
             quality: 'default',
             format: 'default'
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(src);
+      });
+
+      it('should include custom DPR as a string', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'upload';
+        const publicId = 'myimage';
+        const dpr = '2.0';
+
+        const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/dpr_${dpr}/f_auto/q_auto/${publicId}?_a=B`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: publicId,
+            width: 100,
+            height: 100,
+            dpr
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(src);
+      });
+
+      it('should include custom DPR as number', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'upload';
+        const publicId = 'myimage';
+        const dpr = 2;
+
+        const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/dpr_${dpr.toFixed(1)}/f_auto/q_auto/${publicId}?_a=B`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: publicId,
+            width: 100,
+            height: 100,
+            dpr
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+
+        expect(url).toContain(src);
+      });
+      it('should include DPR auto', () => {
+        const cloudName = 'customtestcloud';
+        const deliveryType = 'upload';
+        const publicId = 'myimage';
+        const dpr = 'auto';
+
+        const src = `https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_100/dpr_${dpr}/f_auto/q_auto/${publicId}?_a=B`;
+
+        const url = constructCloudinaryUrl({
+          options: {
+            src: publicId,
+            width: 100,
+            height: 100,
+            dpr
           },
           config: {
             cloud: {


### PR DESCRIPTION
# Description

Adds ability to set DPR on delivery URL

```
const url = constructCloudinaryUrl({
          options: {
            src: publicId,
            width: 100,
            height: 100,
            dpr: '2.0' // or number or auto
          }
})
```

If setting a number, it will automatically be set toFixed(1) 

## Issue Ticket Number

Fixes #76 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
