### PR TITLE
Make PluginSettings generic

### DIFF
--- a/packages/url-loader/src/plugins/fill-background.ts
+++ b/packages/url-loader/src/plugins/fill-background.ts
@@ -6,9 +6,9 @@ export const assetTypes = ['image', 'images'];
 
 const defaultCrop = 'pad';
 
-export function plugin(props: PluginSettings) {
+export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
-  const { fillBackground } = options as ImageOptions; // why do i need to cast it here?;
+  const { fillBackground } = options;
 
   if ( fillBackground === true ) {
     const properties = [

--- a/packages/url-loader/src/plugins/remove-background.ts
+++ b/packages/url-loader/src/plugins/remove-background.ts
@@ -1,9 +1,10 @@
+import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['removeBackground'];
 export const assetTypes = ['image', 'images'];
 
-export function plugin(props: PluginSettings) {
+export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
   const { removeBackground = false } = options;
   if ( removeBackground ) {

--- a/packages/url-loader/src/plugins/sanitize.ts
+++ b/packages/url-loader/src/plugins/sanitize.ts
@@ -1,9 +1,10 @@
+import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
 export const props = ['sanitize'];
 export const assetTypes = ['image', 'images'];
 
-export function plugin(props: PluginSettings) {
+export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
   const { sanitize = true } = options;
 

--- a/packages/url-loader/src/plugins/video.ts
+++ b/packages/url-loader/src/plugins/video.ts
@@ -1,5 +1,6 @@
 import { objectHasKey } from '@cloudinary-util/util';
 
+import { VideoOptions } from '../types/video';
 import { PluginSettings } from '../types/plugins';
 
 import { video as qualifiersVideo } from '../constants/qualifiers';
@@ -8,7 +9,7 @@ import { constructTransformation } from '../lib/transformations';
 export const props = [...Object.keys(qualifiersVideo)];
 export const assetTypes = ['video', 'videos'];
 
-export function plugin(props: PluginSettings) {
+export function plugin(props: PluginSettings<VideoOptions>) {
   const { cldAsset, options } = props;
 
   (Object.keys(options) as Array<keyof typeof options>).forEach(key => {

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -4,9 +4,9 @@ import { PluginSettings, PluginOverrides } from '../types/plugins';
 export const props = ['zoompan'];
 export const assetTypes = ['image', 'images'];
 
-export function plugin(props: PluginSettings) {
+export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
-  const { zoompan = false } = options as ImageOptions; // why do i need to cast it here?
+  const { zoompan = false } = options;
 
   const overrides: PluginOverrides = {
     format: undefined

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -2,9 +2,11 @@ import { AssetOptions } from './asset';
 import { ImageOptions } from './image';
 import { VideoOptions } from './video';
 
-export interface PluginSettings {
+type AllOptions = AssetOptions | ImageOptions | VideoOptions;
+
+export interface PluginSettings<Options extends AllOptions = AllOptions> {
   cldAsset: any;
-  options: AssetOptions | ImageOptions | VideoOptions;
+  options: Options;
 }
 
 export interface PluginOverrides {


### PR DESCRIPTION
# Description

Made `PluginSettings` a generic type, accepting type parameters to make plugin `options` more accurate.

I also updated the `options` type for some affected plugins:
- I added the `ImageOptions` type parameter for plugins with `assetTypes = ['image', 'images']`.
- I added the `VideoOptions` type parameter for plugins with `assetTypes = ['video', 'videos']`.
- I did not pass a type parameter for the plugins with `assetTypes = ['image', 'images', 'video', 'videos']`, so they should default to `AllOptions` instead.

## Issue Ticket Number

Fixes #74 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
