### PR TITLE
feat: Generative Replace (#68)

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -10,6 +10,7 @@ import * as overlaysPlugin from '../plugins/overlays';
 import * as namedTransformationsPlugin from '../plugins/named-transformations';
 import * as rawTransformationsPlugin from '../plugins/raw-transformations';
 import * as removeBackgroundPlugin from '../plugins/remove-background';
+import * as generativeReplacePlugin from '../plugins/generative-replace';
 import * as seoPlugin from '../plugins/seo';
 import * as underlaysPlugin from '../plugins/underlays';
 import * as versionPlugin from '../plugins/version';
@@ -21,8 +22,9 @@ import { AnalyticsOptions } from '../types/analytics';
 import { ConfigOptions } from '../types/config';
 
 export const transformationPlugins = [
-  // Background Removal must always come first
 
+  // Background Removal and Generative Replace must always come first
+  generativeReplacePlugin,
   removeBackgroundPlugin,
 
   // Raw transformations should always come before

--- a/packages/url-loader/src/plugins/generative-replace.ts
+++ b/packages/url-loader/src/plugins/generative-replace.ts
@@ -1,0 +1,37 @@
+import { ImageOptions } from "../types/image";
+import { PluginSettings } from "../types/plugins";
+
+export const props = ["replace"];
+export const assetTypes = ["image", "images"];
+
+export function plugin(props: PluginSettings<ImageOptions>) {
+  const { cldAsset, options } = props;
+  const { replace = null } = options;
+
+  if (replace) {
+    let from: string,
+      to: string,
+      preserveGeometry: boolean = false;
+
+    if (Array.isArray(replace)) {
+      from = replace[0] as string;
+      to = replace[1] as string;
+      preserveGeometry = (replace[2] as boolean) || false;
+    } else {
+      from = replace.from;
+      to = replace.to;
+      preserveGeometry = replace.preserveGeometry || false;
+    }
+
+    const properties = [`e_gen_replace:from_${from}`, `to_${to}`];
+
+    // This property defaults to false, so we only need to pass it if it's true
+    if (preserveGeometry) {
+      properties.push(`preserve-geometry_${preserveGeometry}`);
+    }
+
+    cldAsset.effect(properties.join(";"));
+  }
+
+  return {};
+}

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -1,4 +1,4 @@
-import type { AssetOptions, AssetOptionsResize } from './asset';
+import type { AssetOptions, AssetOptionsResize } from "./asset";
 
 export interface ImageOptionsFillBackground {
   crop?: string;
@@ -8,6 +8,12 @@ export interface ImageOptionsFillBackground {
 
 export interface ImageOptionsResize extends AssetOptionsResize {}
 
+export interface ImageOptionsGenerativeReplace {
+  to: string;
+  from: string;
+  preserveGeometry?: boolean;
+}
+
 export interface ImageOptionsZoomPan {
   loop: string | boolean;
   options: string;
@@ -15,5 +21,6 @@ export interface ImageOptionsZoomPan {
 
 export interface ImageOptions extends AssetOptions {
   fillBackground?: boolean | ImageOptionsFillBackground;
+  replace?: Array<string | boolean> | ImageOptionsGenerativeReplace;
   zoompan?: string | boolean | ImageOptionsZoomPan;
 }

--- a/packages/url-loader/tests/plugins/generative-replace.spec.js
+++ b/packages/url-loader/tests/plugins/generative-replace.spec.js
@@ -1,0 +1,99 @@
+import { Cloudinary } from "@cloudinary/url-gen";
+
+import * as generativeReplacePlugin from "../../src/plugins/generative-replace";
+
+const { plugin } = generativeReplacePlugin;
+
+const cld = new Cloudinary({
+  cloud: {
+    cloudName: "test-cloud-name",
+  },
+});
+
+const TEST_PUBLIC_ID = "test-public-id";
+
+describe("Plugins", () => {
+  describe("Generative Replace", () => {
+    it("should replace with object", () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        replace: {
+          from: "apple",
+          to: "orange",
+        },
+      };
+
+      plugin({
+        cldAsset: cldImage,
+        options,
+      });
+
+      expect(cldImage.toURL()).toContain(`e_gen_replace:from_apple;to_orange`);
+    });
+
+    it("should replace with object and preserved geometry", () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        replace: {
+          from: "apple",
+          to: "orange",
+          preserveGeometry: true,
+        },
+      };
+
+      plugin({
+        cldAsset: cldImage,
+        options,
+      });
+
+      expect(cldImage.toURL()).toContain(
+        `e_gen_replace:from_apple;to_orange;preserve-geometry_true`
+      );
+    });
+
+    it("should replace with array", () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        replace: ["apple", "orange"],
+      };
+
+      plugin({
+        cldAsset: cldImage,
+        options,
+      });
+
+      expect(cldImage.toURL()).toContain(`e_gen_replace:from_apple;to_orange`);
+    });
+
+    it("should replace with array and preserved geometry", () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const options = {
+        replace: ["apple", "candy bar", "true"],
+      };
+
+      plugin({
+        cldAsset: cldImage,
+        options,
+      });
+
+      expect(cldImage.toURL()).toContain(
+        `e_gen_replace:from_apple;to_candy%20bar;preserve-geometry_true`
+      );
+    });
+
+    it("should not attempt generative replace", () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      plugin({
+        cldAsset: cldImage,
+        options: {},
+      });
+
+      expect(cldImage.toURL()).not.toContain(`e_gen_replace`);
+    });
+  });
+});


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Added Generative Replace. Can be utilized in one of two ways:

```js
{
  replace: {
    from: "apple",
    to: "orange",
  }
}
```

or

```js
{
  replace: [ "apple", "orange" ]
}
```

Both options provide the preserve-geometry boolean parameter via the `preserveGeometry` property or as third option in the array.

This also includes 5 new tests for the plugin (and various ways of using it.)

## Issue Ticket Number

Fixes #68

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
