### PR TITLE
Strict Transformations

### DIFF
--- a/packages/url-loader/src/plugins/named-transformations.ts
+++ b/packages/url-loader/src/plugins/named-transformations.ts
@@ -2,6 +2,7 @@ import { PluginSettings } from '../types/plugins';
 
 export const props = ['transformations'];
 export const assetTypes = ['image', 'images', 'video', 'videos'];
+export const strict = true;
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -20,6 +20,7 @@ export interface AssetOptions {
   sanitize?: boolean;
   resize?: AssetOptionsResize;
   seoSuffix?: string;
+  strictTransformations?: boolean;
   src: string;
   text?: any;
   transformations?: Array<string>;

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -13,3 +13,10 @@ export interface PluginOverrides {
   format?: string;
   width?: number;
 }
+
+export interface TransformationPlugin {
+  assetTypes: Array<string>;
+  plugin: Function;
+  props: Array<string>;
+  strict?: boolean;
+}

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -482,6 +482,71 @@ describe('Cloudinary', () => {
 
     })
 
+    /* Strict Transformations */
+
+    describe('strictTransformations', () => {
+
+      it('should not add any transformations when strict transformations is enabled', () => {
+        const cloudName = 'customtestcloud';
+        const src = 'turtle';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            strictTransformations: true
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`image/upload/${src}`);
+      });
+
+      it('should add named transformations when strict transformations is enabled', () => {
+        const cloudName = 'customtestcloud';
+        const src = 'turtle';
+        const namedTransformation = 'my-transformation';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            strictTransformations: true,
+            transformations: [namedTransformation]
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`image/upload/t_${namedTransformation}/${src}`);
+      });
+
+      it('should not add any transformations when strict transformations is enabled', () => {
+        const cloudName = 'customtestcloud';
+        const src = 'turtle';
+        const url = constructCloudinaryUrl({
+          options: {
+            src,
+            strictTransformations: true,
+            removeBackground: true,
+            width: 100,
+            height: 200,
+            effects: [{
+              opacity: .5
+            }]
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          }
+        });
+        expect(url).toContain(`image/upload/${src}`);
+      });
+
+    })
+
     /* General Plugins */
 
     describe('Plugins', () => {


### PR DESCRIPTION
# Description

Adds support for strict transformations to `constructCloudinaryUrl` which prevents any transformations from being applied to the URL except named transformations.

Add `strictTransformations: true` when building the URL.

See added tests for examples.

## Issue Ticket Number

Fixes #82 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
