### PR TITLE
Aspect Ratio as top level option

### DIFF
--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -1,12 +1,14 @@
 import { PluginSettings, PluginOverrides } from '../types/plugins';
 
+const cropsAspectRatio = [ 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
 const cropsGravityAuto = [ 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
 const cropsWithZoom = ['crop', 'thumb'];
 
 export const props = [
+  'aspectRatio',
   'crop',
   'gravity',
-  'zoom'
+  'zoom',
 ];
 export const assetTypes = ['image', 'images', 'video', 'videos'];
 
@@ -24,6 +26,7 @@ export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
 
   const {
+    aspectRatio,
     width: defaultWidth,
     height: defaultHeight,
     widthResize: defaultWidthResize,
@@ -43,10 +46,27 @@ export function plugin(props: PluginSettings) {
   let width = normalizeNumberParameter(defaultWidth);
   let widthResize = normalizeNumberParameter(defaultWidthResize);
 
+  const hasDefinedDimensions = height || width;
+  const hasValidAspectRatio = aspectRatio && cropsAspectRatio.includes(crop);
+
   let transformationString = '';
 
+  // Only apply a crop if we're defining some type of dimension attribute
+  // where the crop would make sense
+
+  if ( crop && ( hasDefinedDimensions || hasValidAspectRatio ) ) {
+    transformationString = `c_${crop}`;
+  }
+
+  // Aspect Ratio requires a crop mode to be applied so we want to make
+  // sure a valid one is included
+
+  if ( hasValidAspectRatio ) {
+    transformationString = `${transformationString},ar_${aspectRatio}`;
+  }
+
   if ( width ) {
-    transformationString = `c_${crop},w_${width}`;
+    transformationString = `${transformationString},w_${width}`;
   }
 
   // Gravity of auto only applies to certain crop types otherewise
@@ -59,7 +79,7 @@ export function plugin(props: PluginSettings) {
   // Some crop types don't need a height and will resize based
   // on the aspect ratio
 
-  if ( !['limit'].includes(crop) ) {
+  if ( !['limit'].includes(crop) && typeof height === 'number' ) {
     transformationString = `${transformationString},h_${height}`;
   }
 

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -4,6 +4,7 @@ export interface AssetOptionsResize {
 }
 
 export interface AssetOptions {
+  aspectRatio?: string | number;
   assetType?: string;
   crop?: string;
   deliveryType?: string;

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -95,4 +95,46 @@ describe('Cropping plugin', () => {
     expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
     expect(pluginOptions).toMatchObject({})
   });
+
+  it('should not apply a height when crop is fill if isnt set', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      width: 100,
+      crop: 'fill',
+    };
+    plugin({ cldAsset: cldImage, options });
+    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},g_auto/${TEST_PUBLIC_ID}`);
+  });
+
+  it('should apply aspect ratio as a string and valid crop', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      aspectRatio: '16:9',
+      crop: 'fill'
+    };
+    plugin({ cldAsset: cldImage, options });
+    expect(cldImage.toURL()).toContain(`c_fill,ar_16:9,g_auto/${TEST_PUBLIC_ID}`);
+  });
+
+  it('should apply aspect ratio as a float and valid crop', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      aspectRatio: .5,
+      crop: 'fill'
+    };
+    plugin({ cldAsset: cldImage, options });
+    // for my own sanity that float => string will add the leading 0
+    expect(`${options.aspectRatio}`).toMatch('0.5');
+    expect(cldImage.toURL()).toContain(`c_fill,ar_${options.aspectRatio},g_auto/${TEST_PUBLIC_ID}`);
+  });
+
+  it('should not apply aspect ratio if not a valid crop', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      aspectRatio: '16:9',
+    };
+    plugin({ cldAsset: cldImage, options });
+    expect(cldImage.toURL()).not.toContain(`ar_16:9`);
+  });
+
 });


### PR DESCRIPTION
# Description

Aspect Ratio is currently only supported in overlays and underlays which is incorrect.

This adds it as a top level option.

aspectRatio="16:9"

## Issue Ticket Number

Fixes #87

And https://github.com/colbyfayock/next-cloudinary/issues/352

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
