### PR TITLE
Flags in Overlays

### DIFF
--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -7,6 +7,7 @@ import { constructTransformation } from '../lib/transformations';
 
 import {
   effects as qualifiersEffects,
+  flags as qualifiersFlags,
   position as qualifiersPosition,
   primary as qualifiersPrimary,
   text as qualifiersText,
@@ -21,6 +22,8 @@ export const DEFAULT_TEXT_OPTIONS = {
   fontSize: 200,
   fontWeight: 'bold',
 };
+
+const supportedFlags = Object.entries(qualifiersFlags).map(([_, { qualifier }]) => qualifier);
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
@@ -62,15 +65,17 @@ export function plugin(props: PluginSettings) {
   }
 
   interface ApplyOverlaySettings {
-    appliedEffects?: Array<object>
+    appliedEffects?: Array<object>;
     effects?: Array<object>;
+    appliedFlags?: Array<string>;
+    flags?: Array<string>;
     position?: string;
     publicId?: string;
     text?: string | ApplyOverlaySettingsText;
     url?: string;
   }
 
-  function applyOverlay({ publicId, url, position, text, effects: layerEffects = [], appliedEffects = [], ...options }: ApplyOverlaySettings) {
+  function applyOverlay({ publicId, url, position, text, effects: layerEffects = [], appliedEffects = [], flags: layerFlags = [], appliedFlags = [], ...options }: ApplyOverlaySettings) {
     const hasPublicId = typeof publicId === 'string';
     const hasUrl = typeof url === 'string';
     const hasText = typeof text === 'object' || typeof text === 'string';
@@ -159,6 +164,22 @@ export function plugin(props: PluginSettings) {
           applied.push(transformation);
         }
       });
+    });
+
+    // Layer Flags
+    // Add flags to the primary layer transformation segment
+
+    layerFlags.forEach(flag => {
+      if ( !supportedFlags.includes(flag) ) return;
+      primary.push(`fl_${flag}`);
+    });
+
+    // Applied Flags
+    // Add flags to the fl_layer_apply transformation segment
+
+    appliedFlags.forEach(flag => {
+      if ( !supportedFlags.includes(flag) ) return;
+      applied.push(`fl_${flag}`);
     });
 
     // Text styling

--- a/packages/url-loader/tests/plugins/overlays.spec.js
+++ b/packages/url-loader/tests/plugins/overlays.spec.js
@@ -116,6 +116,53 @@ describe('Plugins', () => {
       expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')},w_${width},h_${height}/fl_layer_apply,fl_no_overflow,e_screen`);
     });
 
+    it('should apply flags to an overlay', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const publicId = 'images/my-cool-image'
+      const width = '1.0';
+      const flags = ['relative']
+
+      const options = {
+        overlays: [{
+          publicId,
+          width,
+          flags
+        }]
+      }
+
+      plugin({
+        cldAsset: cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')},w_${width},${flags.map(f => `fl_${f}`).join(',')}/fl_layer_apply,fl_no_overflow`);
+    });
+
+    it('should apply applied flags to an overlay', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const publicId = 'images/my-cool-image'
+      const width = '1.0';
+      // Not sure this makes sense in this location, but for testing purposes
+      const flags = ['sanitize']
+
+      const options = {
+        overlays: [{
+          publicId,
+          width,
+          appliedFlags: flags
+        }]
+      }
+
+      plugin({
+        cldAsset: cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')},w_${width}/fl_layer_apply,fl_no_overflow,${flags.map(f => `fl_${f}`).join(',')}`);
+    });
+
   })
   describe('Text Overlays', () => {
     it('should add a text overlay with basic settings', () => {


### PR DESCRIPTION
# Description

Allows the ability to pass in flags with overlays such as :

```
overlays: {
  flags: ['relative']
}
```

## Issue Ticket Number

Fixes #98 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
