### PR TITLE
Fixes inability to turn off URL analytics 

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -66,7 +66,7 @@ export const transformationPlugins = [
 export interface ConstructUrlProps {
   options: ImageOptions;
   config?: ConfigOptions;
-  analytics?: AnalyticsOptions;
+  analytics?: AnalyticsOptions | false;
 }
 
 export interface PluginOptionsResize {
@@ -83,7 +83,17 @@ export interface PluginResults {
   options?: PluginOptions;
 }
 
-export function constructCloudinaryUrl({ options, config, analytics }: ConstructUrlProps): string {
+export function constructCloudinaryUrl({ options, config = {}, analytics }: ConstructUrlProps): string {
+  // If someone is explicitly passing in undefined for analytics via the analytics option,
+  // ensure that the URL Gen SDK option is being passed in as false as well
+
+  if ( analytics === false ) {
+    if ( typeof config?.url === 'undefined' ) {
+      config.url = {};
+    }
+    config.url.analytics = false;
+  }
+
   const cld = new Cloudinary(config);
 
   if ( typeof options?.src !== 'string' ) {

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -503,13 +503,7 @@ describe('Cloudinary', () => {
         expect(url).toContain(`?_a=${expectedId}`);
       });
 
-    });
-
-    /* Custom Config */
-
-    describe('analytics', () => {
-
-      it('should include an analytics ID at the end of the URL', () => {
+      it('should include an analytics ID at the end of the URL when using a custom config', () => {
         const cloudName = 'customtestcloud';
         const secureDistribution = 'spacejelly.dev';
         const url = constructCloudinaryUrl({
@@ -526,6 +520,46 @@ describe('Cloudinary', () => {
           }
         });
         expect(url).toContain(`https://${secureDistribution}/${cloudName}`);
+      });
+
+      it('should not include an analytics ID with config.url.analytics set to false', () => {
+        const cloudName = 'customtestcloud';
+        const url = constructCloudinaryUrl({
+          options: {
+            src: 'turtle',
+          },
+          config: {
+            cloud: {
+              cloudName
+            },
+            url: {
+              analytics: false
+            }
+          },
+          analytics: {
+            sdkCode: 'A',
+            sdkSemver: '1.0.0',
+            techVersion: '1.2.3',
+            product: 'B'
+          }
+        });
+        expect(url).not.toContain(`?_a`);
+      });
+
+      it('should not include an analytics ID with analytics set to false', () => {
+        const cloudName = 'customtestcloud';
+        const url = constructCloudinaryUrl({
+          options: {
+            src: 'turtle',
+          },
+          config: {
+            cloud: {
+              cloudName
+            }
+          },
+          analytics: false
+        });
+        expect(url).not.toContain(`?_a`);
       });
 
     });


### PR DESCRIPTION
# Description

Updates the construct URL function to work properly when analytics is disabled.

Previous, passing the config.url.analytics as false would work, but not the analytics function option.

This normalizes behavior and makes sure it works as expected

## Issue Ticket Number

Helps to address issue found: https://github.com/nuxt-modules/cloudinary/pull/174

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
