### PR TITLE
Fixes undefined overlay effect qualifiers from being applied

### DIFF
--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -130,7 +130,13 @@ export function plugin(props: PluginSettings) {
 
     layerEffects.forEach(effect => {
       (Object.keys(effect) as Array<keyof typeof effect>).forEach(key => {
-        const { qualifier, prefix, converters } = qualifiersPrimary[key] || qualifiersEffects[key] || {};
+        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key];
+
+        // If the qualifier isn't defined, it means it doesnt exist
+
+        if ( !effectQualifier ) return;
+
+        const { qualifier, prefix, converters } = effectQualifier;
 
         const transformation = constructTransformation({
           qualifier,
@@ -151,7 +157,13 @@ export function plugin(props: PluginSettings) {
 
     appliedEffects.forEach(effect => {
       (Object.keys(effect) as Array<keyof typeof effect>).forEach(key => {
-        const { qualifier, prefix, converters } = qualifiersPrimary[key] || qualifiersEffects[key] || {};
+        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key];
+
+        // If the qualifier isn't defined, it means it doesnt exist
+
+        if ( !effectQualifier ) return;
+
+        const { qualifier, prefix, converters } = effectQualifier;
 
         const transformation = constructTransformation({
           qualifier,

--- a/packages/url-loader/tests/plugins/overlays.spec.js
+++ b/packages/url-loader/tests/plugins/overlays.spec.js
@@ -163,6 +163,33 @@ describe('Plugins', () => {
       expect(cldImage.toURL()).toContain(`l_${publicId.replace(/\//g, ':')},w_${width}/fl_layer_apply,fl_no_overflow,${flags.map(f => `fl_${f}`).join(',')}`);
     });
 
+    it('should not apply undefined effects', () => {
+      const cldImage = cld.image(TEST_PUBLIC_ID);
+
+      const publicId = 'images/my-cool-image'
+
+      const options = {
+        overlays: [{
+          publicId,
+          effects: [{
+            colby: 'fayock',
+            space: 'jelly'
+          }],
+          appliedEffects: [{
+            colby: 'fayock',
+            space: 'jelly'
+          }]
+        }]
+      }
+
+      plugin({
+        cldAsset: cldImage,
+        options
+      });
+
+      expect(cldImage.toURL()).toContain(`/l_${publicId.replace(/\//g, ':')}/fl_layer_apply,fl_no_overflow/`);
+    });
+
   })
   describe('Text Overlays', () => {
     it('should add a text overlay with basic settings', () => {


### PR DESCRIPTION
# Description

This checks for the existence of an overlay effect qualifier before applying it.

## Issue Ticket Number

Fixes #102 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
