### PR TITLE
Adds positional qualifiers to effects and appliedEffects

### DIFF
--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -130,7 +130,7 @@ export function plugin(props: PluginSettings) {
 
     layerEffects.forEach(effect => {
       (Object.keys(effect) as Array<keyof typeof effect>).forEach(key => {
-        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key];
+        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key] || qualifiersPosition[key];
 
         // If the qualifier isn't defined, it means it doesnt exist
 
@@ -157,7 +157,7 @@ export function plugin(props: PluginSettings) {
 
     appliedEffects.forEach(effect => {
       (Object.keys(effect) as Array<keyof typeof effect>).forEach(key => {
-        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key];
+        const effectQualifier = qualifiersPrimary[key] || qualifiersEffects[key] || qualifiersPosition[key];
 
         // If the qualifier isn't defined, it means it doesnt exist
 

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -701,6 +701,12 @@ describe('Cloudinary', () => {
         const radius = '150';
         const shear = '40:0';
 
+        const overlaySrc = src;
+        const overlayColor = 'blue';
+        const overlayShadow = 100;
+        const overlayX = 0;
+        const overlayY = 0;
+
         const url = constructCloudinaryUrl({
           options: {
             src,
@@ -717,6 +723,27 @@ describe('Cloudinary', () => {
                 gradientFade,
                 cartoonify,
                 radius
+              }
+            ],
+            overlays: [
+              {
+                publicId: overlaySrc,
+                effects: [
+                  {
+                    color: overlayColor,
+                    shadow: overlayShadow,
+                    x: overlayX,
+                    y: overlayY
+                  }
+                ],
+                appliedEffects: [
+                  {
+                    color: overlayColor,
+                    shadow: overlayShadow,
+                    x: overlayX,
+                    y: overlayY
+                  }
+                ],
               }
             ],
             // Note: removeBackground and restore can't actually be used together
@@ -751,6 +778,8 @@ describe('Cloudinary', () => {
           `d_${defaultImage}`,
           `o_${opacity},e_shear:${shear}`,
           `e_cartoonify:${cartoonify},e_gradient_fade,r_${radius}`,
+          `l_${overlaySrc},co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
+          `fl_layer_apply,fl_no_overflow,co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
           `f_auto`,
           `q_auto`,
           src


### PR DESCRIPTION
# Description

This adds the ability to apply positional qualifiers to effects and appliedEffects on overlays

```
effects: [{
    shadow: 100,
    x: 0,
    y: 0
}]
```

## Issue Ticket Number

Fixes #104 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/colbyfayock/cloudinary-util/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
