### PR TITLE
Reverting "pluginProps" to "props" in transformation plugins

### DIFF
--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -136,10 +136,10 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
 
   const propsCheck: Array<string> = [];
 
-  transformationPlugins.forEach(({ pluginProps }) => {
-    const props = Object.keys(pluginProps);
+  transformationPlugins.forEach(({ props }) => {
+    const pluginProps = Object.keys(props);
 
-    props.forEach(prop => {
+    pluginProps.forEach(prop => {
       if ( propsCheck.includes(prop) ) {
         throw new Error(`Option ${prop} already exists!`);
       }
@@ -192,22 +192,22 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
 
   const pluginEffects: PluginOptions = {};
 
-  transformationPlugins.forEach(({ plugin, assetTypes, pluginProps, strict }: TransformationPlugin) => {
+  transformationPlugins.forEach(({ plugin, assetTypes, props, strict }: TransformationPlugin) => {
     const supportedAssetType = typeof options?.assetType !== 'undefined' && assetTypes.includes(options?.assetType);
-    const props = Object.keys(pluginProps);
+    const pluginProps = Object.keys(props);
     const optionsKeys = Object.keys(options);
-    const attemptedUse = props.map(prop => optionsKeys.includes(prop)).filter(isUsed => !!isUsed).length > 0;
+    const attemptedUse = pluginProps.map(prop => optionsKeys.includes(prop)).filter(isUsed => !!isUsed).length > 0;
 
     if ( !supportedAssetType ) {
       if ( attemptedUse ) {
-        console.warn(`One of the following props [${props.join(', ')}] was used with an unsupported asset type [${options?.assetType}]`);
+        console.warn(`One of the following props [${pluginProps.join(', ')}] was used with an unsupported asset type [${options?.assetType}]`);
       }
       return;
     }
 
     if ( options.strictTransformations && !strict ) {
       if ( attemptedUse ) {
-        console.warn(`One of the following props [${props.join(', ')}] was used that is not supported with Strict Transformations.`);
+        console.warn(`One of the following props [${pluginProps.join(', ')}] was used that is not supported with Strict Transformations.`);
       }
       return;
     }

--- a/packages/url-loader/src/plugins/abr.ts
+++ b/packages/url-loader/src/plugins/abr.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { VideoOptions } from '../types/video';
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   streamingProfile: z.string()
     .describe(JSON.stringify({
       text: 'The streaming profile to apply when delivering a video using adaptive bitrate streaming.',

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -8,7 +8,7 @@ const cropsWithZoom = ['crop', 'thumb'];
 
 const DEFAULT_CROP = 'limit';
 
-export const pluginProps = {
+export const props = {
   aspectRatio: parameters.aspectRatio.schema.optional(),
   crop: parameters.crop.schema.default(DEFAULT_CROP).optional(),
   gravity: parameters.gravity.schema.optional(),

--- a/packages/url-loader/src/plugins/default-image.ts
+++ b/packages/url-loader/src/plugins/default-image.ts
@@ -5,7 +5,7 @@ import { PluginSettings } from '../types/plugins';
 
 import { getFormat } from '@cloudinary-util/util';
 
-export const pluginProps = {
+export const props = {
   defaultImage: z.string()
     .describe(JSON.stringify({
       text: 'Configures the default image to use in case the given public ID is not available. Must include file extension.',

--- a/packages/url-loader/src/plugins/effects.ts
+++ b/packages/url-loader/src/plugins/effects.ts
@@ -55,7 +55,7 @@ const effectProps = {
   vignette: qualifiersEffects.vignette.schema.optional(),
 }
 
-export const pluginProps = {
+export const props = {
   effects: z.array(z.object(effectProps))
     .describe(JSON.stringify({
       text: 'Array of objects specifying transformations to be applied to asset.'

--- a/packages/url-loader/src/plugins/fill-background.ts
+++ b/packages/url-loader/src/plugins/fill-background.ts
@@ -5,7 +5,7 @@ import { PluginSettings } from '../types/plugins';
 
 import { crop, gravity } from '../constants/parameters';
 
-export const pluginProps = {
+export const props = {
   fillBackground: z.union([
       z.boolean(),
       z.object({

--- a/packages/url-loader/src/plugins/flags.ts
+++ b/packages/url-loader/src/plugins/flags.ts
@@ -4,7 +4,7 @@ import { PluginSettings } from '../types/plugins';
 
 const { flagsEnum } = parameters;
 
-export const pluginProps = {
+export const props = {
   flags: parameters.flags.schema.optional()
 };
 

--- a/packages/url-loader/src/plugins/named-transformations.ts
+++ b/packages/url-loader/src/plugins/named-transformations.ts
@@ -5,7 +5,7 @@ import { PluginSettings } from '../types/plugins';
 const NamedTransformationSchema = z.string();
 type NamedTransformation = z.infer<typeof NamedTransformationSchema>;
 
-export const pluginProps = {
+export const props = {
   namedTransformations: z.union([
       NamedTransformationSchema,
       z.array(NamedTransformationSchema)

--- a/packages/url-loader/src/plugins/overlays.ts
+++ b/packages/url-loader/src/plugins/overlays.ts
@@ -70,7 +70,7 @@ const overlaySchema = z.object({
   width: width.schema.optional(),
 });
 
-export const pluginProps = {
+export const props = {
   overlay: overlaySchema
     .describe(JSON.stringify({
       text: 'Image or text layer that is applied on top of the base image.',

--- a/packages/url-loader/src/plugins/raw-transformations.ts
+++ b/packages/url-loader/src/plugins/raw-transformations.ts
@@ -5,7 +5,7 @@ import { PluginSettings } from '../types/plugins';
 const RawTransformationSchema = z.string();
 type RawTransformation = z.infer<typeof RawTransformationSchema>;
 
-export const pluginProps = {
+export const props = {
   rawTransformations: z.union([
       RawTransformationSchema,
       z.array(RawTransformationSchema)

--- a/packages/url-loader/src/plugins/recolor.ts
+++ b/packages/url-loader/src/plugins/recolor.ts
@@ -16,7 +16,7 @@ const imageOptionsRecolorSchema = z.object({
   multiple: z.boolean().optional(),
 });
 
-export const pluginProps = {
+export const props = {
   recolor: z.union([
       imageOptionsRecolorPromptSchema,
       imageOptionsRecolorSchema

--- a/packages/url-loader/src/plugins/remove-background.ts
+++ b/packages/url-loader/src/plugins/remove-background.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   removeBackground: z.boolean()
     .describe(JSON.stringify({
       text: 'Removes the background of an image using the Cloudinary AI Background Removal Add-On (Required).',

--- a/packages/url-loader/src/plugins/remove.ts
+++ b/packages/url-loader/src/plugins/remove.ts
@@ -20,7 +20,7 @@ const imageOptionsRemoveSchema = z.object({
   removeShadow: z.boolean().optional()
 })
 
-export const pluginProps = {
+export const props = {
   remove: z.union([
       imageOptionsRemovePromptSchema,
       imageOptionsRemoveSchema,

--- a/packages/url-loader/src/plugins/replace.ts
+++ b/packages/url-loader/src/plugins/replace.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ImageOptions } from "../types/image";
 import { PluginSettings } from "../types/plugins";
 
-export const pluginProps = {
+export const props = {
   replace: z.union([
       z.array(z.string()),
       z.array(z.boolean()),

--- a/packages/url-loader/src/plugins/restore.ts
+++ b/packages/url-loader/src/plugins/restore.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   restore: z.boolean()
     .describe(JSON.stringify({
       text: 'Uses generative AI to restore details in poor quality images or images that may have become degraded through repeated processing and compression.',

--- a/packages/url-loader/src/plugins/sanitize.ts
+++ b/packages/url-loader/src/plugins/sanitize.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ImageOptions } from '../types/image';
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   sanitize: z.boolean()
     .describe(JSON.stringify({
       text: 'Runs a sanitizer on SVG images.',

--- a/packages/url-loader/src/plugins/seo.ts
+++ b/packages/url-loader/src/plugins/seo.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   seoSuffix: z.string()
     .describe(JSON.stringify({
       text: 'Configures the URL to include an SEO-friendly suffix in the URL',

--- a/packages/url-loader/src/plugins/underlays.ts
+++ b/packages/url-loader/src/plugins/underlays.ts
@@ -31,7 +31,7 @@ const underlaySchema = z.object({
   width: width.schema.optional(),
 });
 
-export const pluginProps = {
+export const props = {
   underlay: z.string()
     .describe(JSON.stringify({
       text: 'Public ID of image that is applied under the base image.',

--- a/packages/url-loader/src/plugins/version.ts
+++ b/packages/url-loader/src/plugins/version.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { PluginSettings } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   version: z.union([
       z.number(),
       z.string()

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ImageOptions } from '../types/image';
 import { PluginSettings, PluginOverrides } from '../types/plugins';
 
-export const pluginProps = {
+export const props = {
   zoompan: z.union([
       z.string(),
       z.boolean(),

--- a/packages/url-loader/src/types/asset.ts
+++ b/packages/url-loader/src/types/asset.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 
-import { pluginProps as croppingPluginProps } from '../plugins/cropping';
-import { pluginProps as effectsPluginProps } from '../plugins/effects';
-import { pluginProps as flagsPluginProps } from '../plugins/flags';
-import { pluginProps as namedTransformationsPluginProps } from '../plugins/named-transformations';
-import { pluginProps as overlaysPluginProps } from '../plugins/overlays';
-import { pluginProps as rawTransformationsPluginProps } from '../plugins/raw-transformations';
-import { pluginProps as removeBackgroundPluginProps } from '../plugins/remove-background';
-import { pluginProps as sanitizePluginProps } from '../plugins/sanitize';
-import { pluginProps as seoPluginProps } from '../plugins/seo';
-import { pluginProps as underlaysPluginProps } from '../plugins/underlays';
-import { pluginProps as versionPluginProps } from '../plugins/version';
+import { props as croppingPluginProps } from '../plugins/cropping';
+import { props as effectsPluginProps } from '../plugins/effects';
+import { props as flagsPluginProps } from '../plugins/flags';
+import { props as namedTransformationsPluginProps } from '../plugins/named-transformations';
+import { props as overlaysPluginProps } from '../plugins/overlays';
+import { props as rawTransformationsPluginProps } from '../plugins/raw-transformations';
+import { props as removeBackgroundPluginProps } from '../plugins/remove-background';
+import { props as sanitizePluginProps } from '../plugins/sanitize';
+import { props as seoPluginProps } from '../plugins/seo';
+import { props as underlaysPluginProps } from '../plugins/underlays';
+import { props as versionPluginProps } from '../plugins/version';
 
 // Asset Options
 

--- a/packages/url-loader/src/types/image.ts
+++ b/packages/url-loader/src/types/image.ts
@@ -2,13 +2,13 @@ import { z } from 'zod';
 
 import { assetOptionsSchema } from './asset';
 
-import { pluginProps as defaultImagePluginProps } from '../plugins/default-image';
-import { pluginProps as fillBackgroundPluginProps } from '../plugins/fill-background';
-import { pluginProps as recolorPluginProps } from '../plugins/recolor';
-import { pluginProps as removePluginProps } from '../plugins/remove';
-import { pluginProps as restorePluginProps } from '../plugins/restore';
-import { pluginProps as replacePluginProps } from '../plugins/replace';
-import { pluginProps as zoompanPluginProps } from '../plugins/zoompan';
+import { props as defaultImagePluginProps } from '../plugins/default-image';
+import { props as fillBackgroundPluginProps } from '../plugins/fill-background';
+import { props as recolorPluginProps } from '../plugins/recolor';
+import { props as removePluginProps } from '../plugins/remove';
+import { props as restorePluginProps } from '../plugins/restore';
+import { props as replacePluginProps } from '../plugins/replace';
+import { props as zoompanPluginProps } from '../plugins/zoompan';
 
 export const imageOptionsSchema = assetOptionsSchema.merge(z.object({
   // Spreading plugins instead of extend or merge to avoid excessive schema warning

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -18,5 +18,5 @@ export interface TransformationPlugin {
   assetTypes: Array<string>;
   plugin: Function;
   strict?: boolean;
-  pluginProps: object;
+  props: object;
 }

--- a/packages/url-loader/src/types/video.ts
+++ b/packages/url-loader/src/types/video.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { assetOptionsSchema } from './asset';
 
-import { pluginProps as abrPluginProps } from '../plugins/abr';
+import { props as abrPluginProps } from '../plugins/abr';
 
 export const videoOptionsSchema = assetOptionsSchema.merge(z.object({
   // Spreading plugins instead of extend or merge to avoid excessive schema warning


### PR DESCRIPTION
# Description

A change from `props` to `pluginProps` was inadvertently made inside internal plugin naming which had an effect on the plugins being exported and imported in consumer libraries.

Reverting this change to avoid it as a breaking change and wasn't intended.

Pulling this commit into `main` from https://github.com/colbyfayock/cloudinary-util/pull/134

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/colbyfayock/cloudinary-util/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/colbyfayock/cloudinary-util/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
