### PR TITLE
Reworking Resizing / Cropping

### DIFF
--- a/packages/url-loader/src/constants/parameters.ts
+++ b/packages/url-loader/src/constants/parameters.ts
@@ -1,5 +1,24 @@
 import { z } from 'zod';
 
+/** Shared */
+
+export const cropModesEnum = z.enum([
+  'fill',
+  'lfill',
+  'fill_pad',
+  'crop',
+  'thumb',
+  'scale',
+  'fit',
+  'limit',
+  'mfit',
+  'pad',
+  'lpad',
+  'mpad',
+  'imagga_scale',
+  'imagga_crop',
+]);
+
 /** Angle - a */
 
 export const angle = {
@@ -40,23 +59,6 @@ export const aspectRatio = {
 
 
 /** Crop */
-
-export const cropModesEnum = z.enum([
-  'fill',
-  'lfill',
-  'fill_pad',
-  'crop',
-  'thumb',
-  'scale',
-  'fit',
-  'limit',
-  'mfit',
-  'pad',
-  'lpad',
-  'mpad',
-  'imagga_scale',
-  'imagga_crop',
-]);
 
 export const crop = {
   qualifier: 'c',
@@ -169,15 +171,34 @@ export const width = {
 }
 
 
-/** Width Resize */
+/** Base Resizing */
 
-export const widthResize = {
+export const baseCrop = {
+  qualifier: 'c',
+  schema: cropModesEnum
+    .describe(JSON.stringify({
+      text: 'Mode to use when cropping an asset\'s "base canvas".',
+      url: 'https://cloudinary.com/documentation/transformation_reference#c_crop_resize'
+    })),
+}
+
+export const baseHeight = {
   schema: z.union([
       z.string(),
       z.number()
     ])
     .describe(JSON.stringify({
-      text: 'Width to resize the asset after all transformations are applied. Useful for responsive resizing.',
+      text: 'Height to resize the asset before all transformations are applied. Useful providing a "base canvas" for applying transformations like text overlays"',
+    })),
+}
+
+export const baseWidth = {
+  schema: z.union([
+      z.string(),
+      z.number()
+    ])
+    .describe(JSON.stringify({
+      text: 'Width to resize the asset before all transformations are applied. Useful providing a "base canvas" for applying transformations like text overlays"',
     })),
 }
 

--- a/packages/url-loader/src/constants/parameters.ts
+++ b/packages/url-loader/src/constants/parameters.ts
@@ -88,13 +88,15 @@ export const aspectRatioModesEnum = z.enum([
   'auto_left',
 ]);
 
+const aspectRatioSchema = z.union([
+  z.number(),
+  aspectRatioModesEnum,
+  z.string(),
+]);
+
 export const aspectRatio = {
   qualifier: 'ar',
-  schema: z.union([
-      z.number(),
-      aspectRatioModesEnum,
-      z.string(),
-    ])
+  schema: aspectRatioSchema
     .describe(JSON.stringify({
       text: 'Crops or resizes the asset to a new aspect ratio.',
       url: 'https://cloudinary.com/documentation/transformation_reference#ar_aspect_ratio'
@@ -104,9 +106,11 @@ export const aspectRatio = {
 
 /** Crop */
 
+const cropSchema = cropModesEnum;
+
 export const crop = {
   qualifier: 'c',
-  schema: cropModesEnum
+  schema: cropSchema
     .describe(JSON.stringify({
       text: 'Mode to use when cropping an asset.',
       url: 'https://cloudinary.com/documentation/transformation_reference#c_crop_resize'
@@ -142,9 +146,11 @@ export const format = {
 
 /** Gravity */
 
+const gravitySchema = z.string();
+
 export const gravity = {
   qualifier: 'g',
-  schema: z.string()
+  schema: gravitySchema
     .describe(JSON.stringify({
       text: 'Determines which part of an asset to focus on. Note: Default of auto is applied for supported crop modes only.',
       url: 'https://cloudinary.com/documentation/transformation_reference#g_gravity'
@@ -154,12 +160,14 @@ export const gravity = {
 
 /** Height */
 
+const heightSchema = z.union([
+  z.number(),
+  z.string()
+])
+
 export const height = {
   qualifier: 'h',
-  schema: z.union([
-      z.number(),
-      z.string()
-    ])
+  schema: heightSchema
     .describe(JSON.stringify({
       text: 'A qualifier that determines the height of a transformed asset or an overlay.',
       url: 'https://cloudinary.com/documentation/transformation_reference#h_height',
@@ -169,12 +177,14 @@ export const height = {
 
 /** Width */
 
+const widthSchema = z.union([
+  z.number(),
+  z.string()
+]);
+
 export const width = {
   qualifier: 'w',
-  schema: z.union([
-      z.number(),
-      z.string()
-    ])
+  schema: widthSchema
     .describe(JSON.stringify({
       text: 'A qualifier that sets the desired width of an asset using a specified value, or automatically based on the available width.',
       url: 'https://cloudinary.com/documentation/transformation_reference#w_width',
@@ -213,8 +223,10 @@ export const y = {
 
 /** Zoom */
 
+const zoomSchema = z.string()
+
 export const zoom = {
-  schema: z.string()
+  schema: zoomSchema
     .describe(JSON.stringify({
       text: 'Controls how close to crop to the detected coordinates when using face-detection, custom-coordinate, or object-specific gravity.',
       url: 'https://cloudinary.com/documentation/transformation_reference#z_zoom'
@@ -224,9 +236,50 @@ export const zoom = {
 
 /** Base Resizing */
 
-export const baseAspectRatio = { ...aspectRatio };
-export const baseCrop = { ...crop };
-export const baseGravity = { ...gravity };
-export const baseHeight = { ...height };
-export const baseWidth = { ...width };
-export const baseZoom = { ...zoom };
+export const baseAspectRatio = {
+  schema: aspectRatioSchema
+    .describe(JSON.stringify({
+      text: 'Crops or resizes the asset to a new aspect ratio. This option is applied to the base layer / original asset.',
+      url: 'https://cloudinary.com/documentation/transformation_reference#ar_aspect_ratio'
+    })),
+};
+
+export const baseCrop = {
+  schema: cropSchema
+    .describe(JSON.stringify({
+      text: 'Mode to use when cropping an asset. This option is applied to the base layer / original asset.',
+      url: 'https://cloudinary.com/documentation/transformation_reference#c_crop_resize'
+    })),
+};
+
+export const baseGravity = {
+  schema: gravitySchema
+  .describe(JSON.stringify({
+    text: 'Determines which part of an asset to focus on. Note: Default of auto is applied for supported crop modes only. This option is applied to the base layer / original asset.',
+    url: 'https://cloudinary.com/documentation/transformation_reference#g_gravity'
+  })),
+};
+
+export const baseHeight = {
+  schema: heightSchema
+  .describe(JSON.stringify({
+    text: 'A qualifier that determines the height of a transformed asset or an overlay. This option is applied to the base layer / original asset.',
+    url: 'https://cloudinary.com/documentation/transformation_reference#h_height',
+  })),
+};
+
+export const baseWidth = {
+  schema: widthSchema
+  .describe(JSON.stringify({
+    text: 'A qualifier that sets the desired width of an asset using a specified value, or automatically based on the available width. This option is applied to the base layer / original asset.',
+    url: 'https://cloudinary.com/documentation/transformation_reference#w_width',
+  })),
+};
+
+export const baseZoom = {
+  schema: zoomSchema
+    .describe(JSON.stringify({
+      text: 'Controls how close to crop to the detected coordinates when using face-detection, custom-coordinate, or object-specific gravity. This option is applied to the base layer / original asset.',
+      url: 'https://cloudinary.com/documentation/transformation_reference#z_zoom'
+    })),
+};

--- a/packages/url-loader/src/constants/parameters.ts
+++ b/packages/url-loader/src/constants/parameters.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-/** Shared */
+/** enum */
 
 export const cropModesEnum = z.enum([
   'fill',
@@ -17,6 +17,50 @@ export const cropModesEnum = z.enum([
   'mpad',
   'imagga_scale',
   'imagga_crop',
+]);
+
+export const flagsEnum = z.enum([
+  'animated',
+  'any_format',
+  'apng',
+  'attachment',
+  'awebp',
+  'clip',
+  'clip_evenodd',
+  'cutter',
+  'force_icc',
+  'force_strip',
+  'getinfo',
+  'group4',
+  'hlsv3',
+  'ignore_aspect_ratio',
+  'ignore_mask_channels',
+  'immutable_cache',
+  'keep_attribution',
+  'keep_dar',
+  'keep_iptc',
+  'layer_apply',
+  'lossy',
+  'mono',
+  'no_overflow',
+  'no_stream',
+  'png8_fl_png24_fl_png32',
+  'preserve_transparency',
+  'progressive',
+  'rasterize',
+  'region_relative',
+  'relative',
+  'replace_image',
+  'sanitize',
+  'splice',
+  'streaming_attachment',
+  'strip_profile',
+  'text_disallow_overflow',
+  'text_no_trim',
+  'tiff8_lzw',
+  'tiled',
+  'truncate_ts',
+  'waveform',
 ]);
 
 /** Angle - a */
@@ -72,50 +116,6 @@ export const crop = {
 
 /** Flags */
 
-export const flagsEnum = z.enum([
-  'animated',
-  'any_format',
-  'apng',
-  'attachment',
-  'awebp',
-  'clip',
-  'clip_evenodd',
-  'cutter',
-  'force_icc',
-  'force_strip',
-  'getinfo',
-  'group4',
-  'hlsv3',
-  'ignore_aspect_ratio',
-  'ignore_mask_channels',
-  'immutable_cache',
-  'keep_attribution',
-  'keep_dar',
-  'keep_iptc',
-  'layer_apply',
-  'lossy',
-  'mono',
-  'no_overflow',
-  'no_stream',
-  'png8_fl_png24_fl_png32',
-  'preserve_transparency',
-  'progressive',
-  'rasterize',
-  'region_relative',
-  'relative',
-  'replace_image',
-  'sanitize',
-  'splice',
-  'streaming_attachment',
-  'strip_profile',
-  'text_disallow_overflow',
-  'text_no_trim',
-  'tiff8_lzw',
-  'tiled',
-  'truncate_ts',
-  'waveform',
-]);
-
 export const flags = {
   qualifier: 'fl',
   schema: z.union([
@@ -128,6 +128,17 @@ export const flags = {
     }))
 }
 
+/** Format */
+
+export const format = {
+  qualifier: 'f',
+  // @TODO: enum
+  schema: z.string()
+    .describe(JSON.stringify({
+      text: 'Converts (if necessary) and delivers an asset in the specified format regardless of the file extension used in the delivery URL.',
+      url: 'https://cloudinary.com/documentation/transformation_reference#f_format'
+    })),
+}
 
 /** Gravity */
 
@@ -170,39 +181,6 @@ export const width = {
     })),
 }
 
-
-/** Base Resizing */
-
-export const baseCrop = {
-  qualifier: 'c',
-  schema: cropModesEnum
-    .describe(JSON.stringify({
-      text: 'Mode to use when cropping an asset\'s "base canvas".',
-      url: 'https://cloudinary.com/documentation/transformation_reference#c_crop_resize'
-    })),
-}
-
-export const baseHeight = {
-  schema: z.union([
-      z.string(),
-      z.number()
-    ])
-    .describe(JSON.stringify({
-      text: 'Height to resize the asset before all transformations are applied. Useful providing a "base canvas" for applying transformations like text overlays"',
-    })),
-}
-
-export const baseWidth = {
-  schema: z.union([
-      z.string(),
-      z.number()
-    ])
-    .describe(JSON.stringify({
-      text: 'Width to resize the asset before all transformations are applied. Useful providing a "base canvas" for applying transformations like text overlays"',
-    })),
-}
-
-
 /** X */
 
 export const x = {
@@ -242,3 +220,13 @@ export const zoom = {
       url: 'https://cloudinary.com/documentation/transformation_reference#z_zoom'
     })),
 }
+
+
+/** Base Resizing */
+
+export const baseAspectRatio = { ...aspectRatio };
+export const baseCrop = { ...crop };
+export const baseGravity = { ...gravity };
+export const baseHeight = { ...height };
+export const baseWidth = { ...width };
+export const baseZoom = { ...zoom };

--- a/packages/url-loader/src/index.ts
+++ b/packages/url-loader/src/index.ts
@@ -1,5 +1,5 @@
 export { constructCloudinaryUrl, transformationPlugins } from './lib/cloudinary';
-export type { ConstructUrlProps, PluginOptionsResize, PluginOptions, PluginResults } from './lib/cloudinary';
+export type { ConstructUrlProps } from './lib/cloudinary';
 
 export { effects, position, primary, text } from './constants/qualifiers';
 
@@ -9,5 +9,5 @@ export type { VideoOptions } from './types/video';
 
 export type { AnalyticsOptions, CloudinaryAnalyticsOptions } from './types/analytics';
 export type { ConfigOptions, CloudinaryConfigurationOptions } from './types/config';
-export type { PluginSettings, PluginOverrides } from './types/plugins';
+export type { PluginSettings, PluginOptions, PluginResults } from './types/plugins';
 export type { Qualifier, QualiferConverters } from './types/qualifiers';

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -181,7 +181,6 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
   }
 
   const pluginEffects: PluginOptions = {};
-  let pluginResize;
 
   transformationPlugins.forEach(({ plugin, assetTypes, props, strict }: TransformationPlugin) => {
     const supportedAssetType = typeof options?.assetType !== 'undefined' && assetTypes.includes(options?.assetType);
@@ -208,20 +207,16 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
       options
     });
 
-    const { options: pluginOptions, resize } = results || { options: undefined };
+    const { options: pluginOptions } = results || { options: undefined };
 
     Object.assign(pluginEffects, pluginOptions);
-
-    if ( resize ) {
-      pluginResize = resize;
-    }
   });
 
   // We want to perform any resizing at the end of the end of the transformation
   // sets to allow consistent use of positioning / sizing, especially responsively
 
-  if ( pluginResize ) {
-    cldAsset.addTransformation(pluginResize);
+  if ( typeof pluginEffects.resize === 'string' ) {
+    cldAsset.addTransformation(pluginEffects.resize);
   }
 
   cldAsset.setDeliveryType(options?.deliveryType || 'upload');

--- a/packages/url-loader/src/lib/cloudinary.ts
+++ b/packages/url-loader/src/lib/cloudinary.ts
@@ -28,7 +28,7 @@ import { videoOptionsSchema } from '../types/video';
 import { analyticsOptionsSchema } from '../types/analytics';
 import { configOptionsSchema } from '../types/config';
 
-import { TransformationPlugin } from '../types/plugins';
+import { TransformationPlugin, PluginResults, PluginOptions } from '../types/plugins';
 
 
 export const transformationPlugins = [
@@ -42,6 +42,12 @@ export const transformationPlugins = [
   replacePlugin,
   restorePlugin,
 
+  // Cropping needs to be before any other general transformations
+  // as it provides the option of 2-step resizing where someone
+  // can resize the "base" canvas as well as the final resize
+  // mechanism commonly used for responsive resizing
+  croppingPlugin,
+
   // Raw transformations should always come before
   // other arguments to avoid conflicting with
   // added options via the component
@@ -49,7 +55,6 @@ export const transformationPlugins = [
   rawTransformationsPlugin,
 
   abrPlugin,
-  croppingPlugin,
   defaultImagePlugin,
   effectsPlugin,
   fillBackgroundPlugin,
@@ -97,21 +102,6 @@ export const constructUrlPropsSchema = z.object({
 })
 
 export type ConstructUrlProps = z.infer<typeof constructUrlPropsSchema>;
-
-export interface PluginOptionsResize {
-  crop?: string;
-  width?: string | number;
-}
-
-export interface PluginOptions {
-  format?: string;
-  resize?: PluginOptionsResize;
-  width?: string | number;
-}
-
-export interface PluginResults {
-  options?: PluginOptions;
-}
 
 export function constructCloudinaryUrl({ options, config = {}, analytics }: ConstructUrlProps): string {
   // If someone is explicitly passing in undefined for analytics via the analytics option,
@@ -191,6 +181,7 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
   }
 
   const pluginEffects: PluginOptions = {};
+  let pluginResize;
 
   transformationPlugins.forEach(({ plugin, assetTypes, props, strict }: TransformationPlugin) => {
     const supportedAssetType = typeof options?.assetType !== 'undefined' && assetTypes.includes(options?.assetType);
@@ -217,25 +208,20 @@ export function constructCloudinaryUrl({ options, config = {}, analytics }: Cons
       options
     });
 
-    const { options: pluginOptions } = results || { options: undefined };
+    const { options: pluginOptions, resize } = results || { options: undefined };
 
-    if ( pluginOptions?.format && options ) {
-      pluginEffects.format = pluginOptions.format;
-    }
+    Object.assign(pluginEffects, pluginOptions);
 
-    if ( pluginOptions?.width && options ) {
-      pluginEffects.resize = {
-        width: pluginOptions?.width
-      };
+    if ( resize ) {
+      pluginResize = resize;
     }
   });
 
   // We want to perform any resizing at the end of the end of the transformation
   // sets to allow consistent use of positioning / sizing, especially responsively
 
-  if ( pluginEffects?.resize && !options.strictTransformations ) {
-    const { width, crop = 'limit' } = pluginEffects.resize;
-    cldAsset.effect(`c_${crop},w_${width}`);
+  if ( pluginResize ) {
+    cldAsset.addTransformation(pluginResize);
   }
 
   cldAsset.setDeliveryType(options?.deliveryType || 'upload');

--- a/packages/url-loader/src/lib/transformations.ts
+++ b/packages/url-loader/src/lib/transformations.ts
@@ -48,3 +48,13 @@ export function constructTransformation({ prefix, qualifier, value, converters }
 export function promptArrayToString(promptArray: Array<string>) {
   return `(${promptArray.join(';')})`;
 }
+
+/**
+ * normalizeNumberParameter
+ * @TODO: move into util
+ */
+
+export function normalizeNumberParameter(param: number | string | undefined) {
+  if ( typeof param !== 'string' ) return param;
+  return parseInt(param)
+}

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -2,17 +2,20 @@ import * as parameters from '../constants/parameters';
 
 import { PluginSettings, PluginResults } from '../types/plugins';
 
-const cropsAspectRatio = [ 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
-const cropsGravityAuto = [ 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
+const cropsAspectRatio = [ 'auto', 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
+const cropsGravityAuto = [ 'auto', 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
 const cropsWithZoom = ['crop', 'thumb'];
 
 const DEFAULT_CROP = 'limit';
 
 export const props = {
   aspectRatio: parameters.aspectRatio.schema.optional(),
+  baseAspectRatio: parameters.baseAspectRatio.schema.optional(),
   baseCrop: parameters.baseCrop.schema.optional(),
+  baseGravity: parameters.baseGravity.schema.optional(),
   baseHeight: parameters.baseHeight.schema.optional(),
   baseWidth: parameters.baseWidth.schema.optional(),
+  baseZoom: parameters.baseZoom.schema.optional(),
   crop: parameters.crop.schema.default(DEFAULT_CROP).optional(),
   gravity: parameters.gravity.schema.optional(),
   zoom: parameters.zoom.schema.optional(),
@@ -33,107 +36,113 @@ export function normalizeNumberParameter(param: number | string | undefined) {
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
 
-  const {
-    aspectRatio,
-    baseCrop: defaultBaseCrop,
-    baseHeight: defaultBaseHeight,
-    baseWidth: defaultBaseWidth,
-    gravity: defaultGravity,
-    width: defaultWidth,
-    height: defaultHeight,
-    // Default the crop to "limit" to avoid upscaling, even when widthResize is passed in.
-    // This avoid further distorting the image since the browser will resize in that case.
-    // If caller wants actual resize, can explicitly pass in "scale".
-    crop = DEFAULT_CROP,
-    zoom
-  } = options;
+  
+  // Standard Cropping/Resizing
+  // The final crop and resize for the image to be delivered after any transformations are applied
 
-  // Normalize sizing parameters
-
-  let gravity = defaultGravity;
-  let baseHeight = normalizeNumberParameter(defaultBaseHeight);
-  let baseWidth = normalizeNumberParameter(defaultBaseWidth);
-  let baseCrop = normalizeNumberParameter(defaultBaseCrop);
-  let height = normalizeNumberParameter(defaultHeight);
-  let width = normalizeNumberParameter(defaultWidth);
-
-  const hasDefinedDimensions = height || width;
-  const hasValidAspectRatio = aspectRatio && cropsAspectRatio.includes(crop);
-
-
+  const overrideTransformations = collectTransformations({
+    aspectRatio: options.aspectRatio,
+    width: options.width,
+    height: options.height,
+    gravity: options.gravity,
+    crop: options.crop,
+    zoom: options.zoom,
+  });
 
   // Base Resizing/Cropping
   // This stage provides the option for someone to crop and resize the image before any transformations
   // are applied. this could be handy if you want a consistent size on different assets to share
   // transformations for instance
 
+  const baseTransformations = collectTransformations({
+    aspectRatio: options.baseAspectRatio,
+    width: options.baseWidth,
+    height: options.baseHeight,
+    gravity: options.baseGravity,
+    crop: options.baseCrop,
+    zoom: options.baseZoom,
+  });
 
-  // Standard Cropping/Resizing
-  // The final crop and resize for the image to be delivered after any transformations are applied
+  function collectTransformations(collectOptions: Pick<PluginSettings['options'], "aspectRatio" | "crop" | "gravity" | "height" | "width" | "zoom">) {
+    // Default the crop to "limit" to avoid upscaling
+    // This avoid further distorting the image since the browser will resize in that case.
+    // If caller wants actual resize, can explicitly pass in "scale".
+    const { aspectRatio, crop = DEFAULT_CROP, zoom } = collectOptions;
 
-  const baseTransformations = {};
-  const overrideTransformations = [];
+    // Normalize sizing parameters
 
-  // Only apply a crop if we're defining some type of dimension attribute
-  // where the crop would make sense
+    let gravity = collectOptions.gravity;
+    let height = normalizeNumberParameter(collectOptions.height);
+    let width = normalizeNumberParameter(collectOptions.width);
 
-  if ( crop && ( hasDefinedDimensions || hasValidAspectRatio ) ) {
-    overrideTransformations.push(`c_${crop}`);
-  }
+    const transformations = [];
 
-  // Aspect Ratio requires a crop mode to be applied so we want to make
-  // sure a valid one is included
+    const hasDefinedDimensions = height || width;
+    const hasValidAspectRatio = aspectRatio && cropsAspectRatio.includes(crop);
 
-  if ( hasValidAspectRatio ) {
-    overrideTransformations.push(`ar_${aspectRatio}`);
-  }
+    // Only apply a crop if we're defining some type of dimension attribute
+    // where the crop would make sense
 
-  if ( width ) {
-    overrideTransformations.push(`w_${width}`);
-  }
-
-  // Some crop types don't need a height and will resize based
-  // on the aspect ratio
-
-  if ( !['limit'].includes(crop) && typeof height === 'number' ) {
-    overrideTransformations.push(`h_${height}`);
-  }
-
-  // Gravity of auto only applies to certain crop types otherewise
-  // errors, so default to auto only when crop matches type
-
-  if ( !gravity && cropsGravityAuto.includes(crop) ) {
-    gravity = 'auto';
-  }
-
-  // If we have gravity, apply it, but check that the gravity passed
-  // in doesn't conflict with the crop mode
-
-  if ( gravity ) {
-    if ( gravity === 'auto' && !cropsGravityAuto.includes(crop) ) {
-      console.warn(`Auto gravity can only be used with crop modes: ${cropsGravityAuto.join(', ')}. Not applying gravity.`);
-    } else {
-      overrideTransformations.push(`g_${gravity}`);gravity = gravity;
+    if ( crop && ( hasDefinedDimensions || hasValidAspectRatio ) ) {
+      transformations.push(`c_${crop}`);
     }
-  }
 
-  // Some zoom types don't work with some crop types
+    // Aspect Ratio requires a crop mode to be applied so we want to make
+    // sure a valid one is included
 
-  if ( zoom ) {
-    if ( zoom === 'auto' && !cropsWithZoom.includes(crop) ) {
-      console.warn(`Zoom can only be used with crop modes: ${cropsWithZoom.join(', ')}. Not applying zoom.`);
-    } else {
-      overrideTransformations.push(`z_${zoom}`);
+    if ( hasValidAspectRatio ) {
+      transformations.push(`ar_${aspectRatio}`);
     }
+
+    if ( width ) {
+      transformations.push(`w_${width}`);
+    }
+
+    // Some crop types don't need a height and will resize based
+    // on the aspect ratio
+
+    if ( !['limit'].includes(crop) && typeof height === 'number' ) {
+      transformations.push(`h_${height}`);
+    }
+
+    // Gravity of auto only applies to certain crop types otherewise
+    // errors, so default to auto only when crop matches type
+
+    if ( !gravity && cropsGravityAuto.includes(crop) ) {
+      gravity = 'auto';
+    }
+
+    // If we have gravity, apply it, but check that the gravity passed
+    // in doesn't conflict with the crop mode
+
+    if ( gravity ) {
+      if ( gravity === 'auto' && !cropsGravityAuto.includes(crop) ) {
+        console.warn(`Auto gravity can only be used with crop modes: ${cropsGravityAuto.join(', ')}. Not applying gravity.`);
+      } else {
+        transformations.push(`g_${gravity}`);gravity = gravity;
+      }
+    }
+
+    // Some zoom types don't work with some crop types
+
+    if ( zoom ) {
+      if ( zoom === 'auto' && !cropsWithZoom.includes(crop) ) {
+        console.warn(`Zoom can only be used with crop modes: ${cropsWithZoom.join(', ')}. Not applying zoom.`);
+      } else {
+        transformations.push(`z_${zoom}`);
+      }
+    }
+
+    return transformations;
   }
 
-  // Finally apply the constructed transformation string to the image instance
+  // If we have any base canvas transformations, add them to the image instance
 
-  // cldAsset.effect(transformationString);
+  if ( baseTransformations.length > 0 ) {
+    cldAsset.addTransformation(baseTransformations.join(','));
+  }
 
-  // if ( widthResize ) {
-  //   overrides.width = widthResize;
-  // }
+  // If we have any overrides, which are the the standard width/height options, apply 
   
   const results: PluginResults = {};
 

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -2,6 +2,8 @@ import * as parameters from '../constants/parameters';
 
 import { PluginSettings, PluginResults } from '../types/plugins';
 
+import { normalizeNumberParameter } from '../lib/transformations';
+
 const cropsAspectRatio = [ 'auto', 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
 const cropsGravityAuto = [ 'auto', 'crop', 'fill', 'lfill', 'fill_pad', 'thumb' ];
 const cropsWithZoom = ['crop', 'thumb'];
@@ -23,15 +25,6 @@ export const props = {
 
 export const assetTypes = ['image', 'images', 'video', 'videos'];
 
-/**
- * normalizeNumberParameter
- * @TODO: move into util
- */
-
-export function normalizeNumberParameter(param: number | string | undefined) {
-  if ( typeof param !== 'string' ) return param;
-  return parseInt(param)
-}
 
 export function plugin(props: PluginSettings) {
   const { cldAsset, options } = props;
@@ -119,7 +112,7 @@ export function plugin(props: PluginSettings) {
       if ( gravity === 'auto' && !cropsGravityAuto.includes(crop) ) {
         console.warn(`Auto gravity can only be used with crop modes: ${cropsGravityAuto.join(', ')}. Not applying gravity.`);
       } else {
-        transformations.push(`g_${gravity}`);gravity = gravity;
+        transformations.push(`g_${gravity}`);
       }
     }
 

--- a/packages/url-loader/src/plugins/cropping.ts
+++ b/packages/url-loader/src/plugins/cropping.ts
@@ -137,10 +137,12 @@ export function plugin(props: PluginSettings) {
 
   // If we have any overrides, which are the the standard width/height options, apply 
   
-  const results: PluginResults = {};
+  const results: PluginResults = {
+    options: {}
+  };
 
-  if ( overrideTransformations.length > 0 ) {
-    results.resize = overrideTransformations.join(',');
+  if ( results.options && overrideTransformations.length > 0 ) {
+    results.options.resize = overrideTransformations.join(',');
   }
 
   return results

--- a/packages/url-loader/src/plugins/fill-background.ts
+++ b/packages/url-loader/src/plugins/fill-background.ts
@@ -5,6 +5,8 @@ import { PluginSettings } from '../types/plugins';
 
 import { crop, gravity } from '../constants/parameters';
 
+import { normalizeNumberParameter } from '../lib/transformations';
+
 export const props = {
   fillBackground: z.union([
       z.boolean(),
@@ -29,11 +31,21 @@ export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
   const { fillBackground } = options;
 
+  const width = normalizeNumberParameter(options.width);
+  const height = normalizeNumberParameter(options.height);
+  const hasDefinedDimensions = typeof height === 'number' && typeof width === 'number';
+  let aspectRatio = options.aspectRatio;
+
+  if ( !aspectRatio && hasDefinedDimensions ) {
+    aspectRatio = `${width}:${height}`;
+  }
+
+  if ( !aspectRatio ) return;
+
   if ( fillBackground === true ) {
     const properties = [
       'b_gen_fill',
-      `ar_${options.width}:${options.height}`,
-      `w_${options.width}`,
+      `ar_${aspectRatio}`,
       `c_${defaultCrop}`
     ]
 
@@ -42,8 +54,7 @@ export function plugin(props: PluginSettings<ImageOptions>) {
     const { crop = defaultCrop, gravity, prompt } = fillBackground;
 
     const properties = [
-      `ar_${options.width}:${options.height}`,
-      `w_${options.width}`,
+      `ar_${aspectRatio}`,
       `c_${crop}`
     ]
 

--- a/packages/url-loader/src/plugins/zoompan.ts
+++ b/packages/url-loader/src/plugins/zoompan.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import { ImageOptions } from '../types/image';
-import { PluginSettings, PluginOverrides } from '../types/plugins';
+import { PluginSettings, PluginOptions } from '../types/plugins';
 
 export const props = {
   zoompan: z.union([
@@ -25,7 +25,7 @@ export function plugin(props: PluginSettings<ImageOptions>) {
   const { cldAsset, options } = props;
   const { zoompan = false } = options;
 
-  const overrides: PluginOverrides = {
+  const overrides: PluginOptions = {
     format: undefined
   };
 

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -9,14 +9,24 @@ export interface PluginSettings<Options extends AllOptions = AllOptions> {
   options: Options;
 }
 
-export interface PluginOverrides {
-  format?: string;
-  width?: number;
-}
-
 export interface TransformationPlugin {
   assetTypes: Array<string>;
   plugin: Function;
   strict?: boolean;
   props: object;
+}
+
+export interface PluginOptions {
+  aspectRatio?: string | number;
+  crop?: string;
+  gravity?: string;
+  height?: number;
+  format?: string;
+  width?: string | number;
+  zoom?: string;
+}
+
+export interface PluginResults {
+  options?: PluginOptions;
+  resize?: string;
 }

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -25,6 +25,7 @@ export const pluginOptionsSchema = z.object({
   gravity: gravity.schema.optional(),
   height: height.schema.optional(),
   format: format.schema.optional(),
+  resize: z.string().optional(),
   width: width.schema.optional(),
   zoom: zoom.schema.optional(),
 })
@@ -33,5 +34,4 @@ export type PluginOptions = z.infer<typeof pluginOptionsSchema>;
 
 export interface PluginResults {
   options?: PluginOptions;
-  resize?: string;
 }

--- a/packages/url-loader/src/types/plugins.ts
+++ b/packages/url-loader/src/types/plugins.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+import { aspectRatio, crop, gravity, height, format, width, zoom } from '../constants/parameters';
 import { AssetOptions } from './asset';
 import { ImageOptions } from './image';
 import { VideoOptions } from './video';
@@ -16,15 +18,18 @@ export interface TransformationPlugin {
   props: object;
 }
 
-export interface PluginOptions {
-  aspectRatio?: string | number;
-  crop?: string;
-  gravity?: string;
-  height?: number;
-  format?: string;
-  width?: string | number;
-  zoom?: string;
-}
+
+export const pluginOptionsSchema = z.object({
+  aspectRatio: aspectRatio.schema.optional(),
+  crop: crop.schema.optional(),
+  gravity: gravity.schema.optional(),
+  height: height.schema.optional(),
+  format: format.schema.optional(),
+  width: width.schema.optional(),
+  zoom: zoom.schema.optional(),
+})
+
+export type PluginOptions = z.infer<typeof pluginOptionsSchema>;
 
 export interface PluginResults {
   options?: PluginOptions;

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -182,18 +182,20 @@ describe('Cloudinary', () => {
 
     describe('cropping, resizing', () => {
 
-      it('should create a Cloudinary URL with widthResize smaller than width', () => {
+      it('should create a Cloudinary URL with a width, height, and custom crop', () => {
         const cloudName = 'customtestcloud';
         const deliveryType = 'upload';
         const publicId = 'myimage';
         const width = 900;
-        const widthResize = 600;
+        const height = 900;
+        const crop = 'auto';
 
         const url = constructCloudinaryUrl({
           options: {
             src: publicId,
             width,
-            widthResize
+            height,
+            crop
           },
           config: {
             cloud: {
@@ -201,21 +203,23 @@ describe('Cloudinary', () => {
             }
           }
         });
-        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_${width}/c_limit,w_${widthResize}/f_auto/q_auto/${publicId}`);
+        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_${crop},w_${width},h_${height}/f_auto/q_auto/${publicId}`);
       });
 
-      it('should create a Cloudinary URL with widthResize same as width', () => {
+      it('should create a Cloudinary URL with a aspect ratio, custom crop, zoom, and default gravity', () => {
         const cloudName = 'customtestcloud';
         const deliveryType = 'upload';
         const publicId = 'myimage';
-        const width = 900;
-        const widthResize = 900;
+        const aspectRatio = '16:9';
+        const crop = 'fill';
+        const zoom = '1.2';
 
         const url = constructCloudinaryUrl({
           options: {
             src: publicId,
-            width,
-            widthResize
+            aspectRatio,
+            crop,
+            zoom
           },
           config: {
             cloud: {
@@ -223,29 +227,8 @@ describe('Cloudinary', () => {
             }
           }
         });
-        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_${width}/c_limit,w_${widthResize}/f_auto/q_auto/${publicId}`);
-      });
-
-      it('should create a Cloudinary URL with widthResize larger than width', () => {
-        const cloudName = 'customtestcloud';
-        const deliveryType = 'upload';
-        const publicId = 'myimage';
-        const width = 900;
-        const widthResize = 1200;
-
-        const url = constructCloudinaryUrl({
-          options: {
-            src: publicId,
-            width,
-            widthResize
-          },
-          config: {
-            cloud: {
-              cloudName
-            }
-          }
-        });
-        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_limit,w_${width}/c_limit,w_${widthResize}/f_auto/q_auto/${publicId}`);
+        console.log(url)
+        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_${crop},ar_${aspectRatio},g_auto,z_${zoom}/f_auto/q_auto/${publicId}`);
       });
 
     });
@@ -832,13 +815,13 @@ describe('Cloudinary', () => {
           `e_gen_remove:prompt_apple;multiple_true;remove-shadow_true`,
           `e_background_removal`,
           `e_gen_restore`,
-          `c_limit,w_${width}`,
           `d_${defaultImage}`,
           `o_${opacity},e_shear:${shear}`,
           `e_cartoonify:${cartoonify},e_gradient_fade,r_${radius}`,
           `l_${overlaySrc},co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
           `fl_layer_apply,fl_no_overflow,co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
           `e_zoompan`,
+          `c_limit,w_${width}`,
           `f_auto:animated`, // Effect of zoompan
           `q_auto`,
           src

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -227,7 +227,7 @@ describe('Cloudinary', () => {
             }
           }
         });
-        console.log(url)
+
         expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_${crop},ar_${aspectRatio},g_auto,z_${zoom}/f_auto/q_auto/${publicId}`);
       });
 

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -203,7 +203,7 @@ describe('Cloudinary', () => {
             }
           }
         });
-        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_${crop},w_${width},h_${height}/f_auto/q_auto/${publicId}`);
+        expect(url).toContain(`https://res.cloudinary.com/${cloudName}/image/${deliveryType}/c_${crop},w_${width},h_${height},g_auto/f_auto/q_auto/${publicId}`);
       });
 
       it('should create a Cloudinary URL with a aspect ratio, custom crop, zoom, and default gravity', () => {

--- a/packages/url-loader/tests/lib/cloudinary.spec.js
+++ b/packages/url-loader/tests/lib/cloudinary.spec.js
@@ -730,10 +730,17 @@ describe('Cloudinary', () => {
     it('Kitchen Sink - Image', () => {
       const cloudName = 'customtestcloud';
         const assetType = 'image';
+        const crop = 'auto';
+        const defaultImage = 'my-image.jpg';
+        const height = 321;
         const src = 'turtle';
         const width = 123;
-        const height = 321;
-        const defaultImage = 'my-image.jpg';
+        const zoom = '2.0';
+
+        const baseCrop = 'fill';
+        const baseHeight = 8765;
+        const baseWidth = 4321;
+        const baseZoom = 3;
 
         const cartoonify = '50';
         const gradientFade = true;
@@ -749,11 +756,17 @@ describe('Cloudinary', () => {
 
         const url = constructCloudinaryUrl({
           options: {
+            assetType,
+            baseCrop,
+            baseHeight,
+            baseWidth,
+            baseZoom,
+            crop,
+            defaultImage,
+            height,
             src,
             width,
-            height,
-            assetType,
-            defaultImage,
+            zoom,
             effects: [
               {
                 shear,
@@ -815,13 +828,14 @@ describe('Cloudinary', () => {
           `e_gen_remove:prompt_apple;multiple_true;remove-shadow_true`,
           `e_background_removal`,
           `e_gen_restore`,
+          `c_${baseCrop},w_${baseWidth},h_${baseHeight},g_auto,z_${baseZoom}`,
           `d_${defaultImage}`,
           `o_${opacity},e_shear:${shear}`,
           `e_cartoonify:${cartoonify},e_gradient_fade,r_${radius}`,
           `l_${overlaySrc},co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
           `fl_layer_apply,fl_no_overflow,co_${overlayColor},e_shadow:${overlayShadow},x_${overlayX},y_${overlayY}`,
           `e_zoompan`,
-          `c_limit,w_${width}`,
+          `c_${crop},w_${width},h_${height},g_auto,z_${zoom}`,
           `f_auto:animated`, // Effect of zoompan
           `q_auto`,
           src

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -56,50 +56,37 @@ describe('Cropping plugin', () => {
     expect(resize).toBeUndefined();
   });
 
-  // it('should return resize override with original size in URL if resize is smaller than width', () => {
-  //   const cldImage = cld.image(TEST_PUBLIC_ID);
-  //   const options = {
-  //     width: 900,
-  //     widthResize: 600
-  //   };
+  it('should return resize override width a base width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      baseWidth: 600,
+      width: 900,
+    };
 
-  //   const { options: pluginOptions, resize } = plugin({ cldAsset: cldImage, options });
+    const { resize } = plugin({ cldAsset: cldImage, options });
 
-  //   expect(resize).toContain(`image/upload/c_limit,w_${options.width}`);
-  //   expect(pluginOptions).toMatchObject({
-  //     width: options.widthResize
-  //   })
-  // });
+    expect(resize).toContain(`c_limit,w_${options.width}`);
+    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.baseWidth}`);
+  });
 
-  // it('should return resize override with original size in URL if resize is larger than width', () => {
-  //   const cldImage = cld.image(TEST_PUBLIC_ID);
-  //   const options = {
-  //     width: 900,
-  //     widthResize: 1200
-  //   };
+  it('should return resize override width a base width', () => {
+    const cldImage = cld.image(TEST_PUBLIC_ID);
+    const options = {
+      baseCrop: 'auto',
+      baseHeight: 8765,
+      baseWidth: 4321,
+      baseZoom: 3,
+      crop: 'fill',
+      height: 5678,
+      width: 1234,
+      zoom: 2,
+    };
 
-  //   const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
+    const { resize } = plugin({ cldAsset: cldImage, options });
 
-  //   expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}`);
-  //   expect(pluginOptions).toMatchObject({
-  //     width: options.widthResize
-  //   })
-  // });
-
-  // it('should return resize override with original size in URL if resize is the same as width', () => {
-  //   const cldImage = cld.image(TEST_PUBLIC_ID);
-  //   const options = {
-  //     width: 900,
-  //     widthResize: 900
-  //   };
-
-  //   const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
-
-  //   expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}`);
-  //   expect(pluginOptions).toMatchObject({
-  //     width: options.widthResize
-  //   })
-  // });
+    expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}`);
+    expect(cldImage.toURL()).toContain(`image/upload/c_${options.baseCrop},w_${options.baseWidth},h_${options.baseHeight},g_auto,z_${options.baseZoom}`);
+  });
 
   it('should not apply a height when crop is fill if isnt set', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -22,7 +22,7 @@ describe('Cropping plugin', () => {
       crop: 'crop',
       gravity: 'auto'
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_${options.gravity}`);
   });
 
@@ -33,7 +33,7 @@ describe('Cropping plugin', () => {
       height: 100,
       crop: 'fill'
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto`);
   });
 
@@ -45,14 +45,14 @@ describe('Cropping plugin', () => {
       crop: 'fill',
       zoom: 0.5
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}`);
   });
 
   it('should not include a width if not set', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);
     const options = {};
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toBeUndefined();
   });
 
@@ -63,7 +63,7 @@ describe('Cropping plugin', () => {
       width: 900,
     };
 
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
 
     expect(resize).toContain(`c_limit,w_${options.width}`);
     expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.baseWidth}`);
@@ -82,7 +82,7 @@ describe('Cropping plugin', () => {
       zoom: 2,
     };
 
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
 
     expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}`);
     expect(cldImage.toURL()).toContain(`image/upload/c_${options.baseCrop},w_${options.baseWidth},h_${options.baseHeight},g_auto,z_${options.baseZoom}`);
@@ -94,7 +94,7 @@ describe('Cropping plugin', () => {
       width: 100,
       crop: 'fill',
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_${options.crop},w_${options.width},g_auto`);
   });
 
@@ -104,7 +104,7 @@ describe('Cropping plugin', () => {
       aspectRatio: '16:9',
       crop: 'fill'
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toContain(`c_fill,ar_16:9,g_auto`);
   });
 
@@ -114,7 +114,7 @@ describe('Cropping plugin', () => {
       aspectRatio: .5,
       crop: 'fill'
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     // for my own sanity that float => string will add the leading 0
     expect(`${options.aspectRatio}`).toMatch('0.5');
     expect(resize).toContain(`c_fill,ar_${options.aspectRatio},g_auto`);
@@ -126,7 +126,7 @@ describe('Cropping plugin', () => {
       aspectRatio: '16:9',
       crop: 'fit'
     };
-    const { resize } = plugin({ cldAsset: cldImage, options });
+    const { options: { resize } } = plugin({ cldAsset: cldImage, options });
     expect(resize).toBeUndefined();
   });
 });

--- a/packages/url-loader/tests/plugins/cropping.spec.js
+++ b/packages/url-loader/tests/plugins/cropping.spec.js
@@ -22,8 +22,8 @@ describe('Cropping plugin', () => {
       crop: 'crop',
       gravity: 'auto'
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_${options.gravity}/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_${options.gravity}`);
   });
 
   it('should apply a gravity of auto by default if not set explicitly', () => {
@@ -33,8 +33,8 @@ describe('Cropping plugin', () => {
       height: 100,
       crop: 'fill'
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto`);
   });
 
   it('should apply a zoom if set explicitly', () => {
@@ -45,61 +45,61 @@ describe('Cropping plugin', () => {
       crop: 'fill',
       zoom: 0.5
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_${options.crop},w_${options.width},h_${options.height},g_auto,z_${options.zoom}`);
   });
 
   it('should not include a width if not set', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);
     const options = {};
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`image/upload/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toBeUndefined();
   });
 
-  it('should return resize override with original size in URL if resize is smaller than width', () => {
-    const cldImage = cld.image(TEST_PUBLIC_ID);
-    const options = {
-      width: 900,
-      widthResize: 600
-    };
+  // it('should return resize override with original size in URL if resize is smaller than width', () => {
+  //   const cldImage = cld.image(TEST_PUBLIC_ID);
+  //   const options = {
+  //     width: 900,
+  //     widthResize: 600
+  //   };
 
-    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
+  //   const { options: pluginOptions, resize } = plugin({ cldAsset: cldImage, options });
 
-    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
-    expect(pluginOptions).toMatchObject({
-      width: options.widthResize
-    })
-  });
+  //   expect(resize).toContain(`image/upload/c_limit,w_${options.width}`);
+  //   expect(pluginOptions).toMatchObject({
+  //     width: options.widthResize
+  //   })
+  // });
 
-  it('should return resize override with original size in URL if resize is larger than width', () => {
-    const cldImage = cld.image(TEST_PUBLIC_ID);
-    const options = {
-      width: 900,
-      widthResize: 1200
-    };
+  // it('should return resize override with original size in URL if resize is larger than width', () => {
+  //   const cldImage = cld.image(TEST_PUBLIC_ID);
+  //   const options = {
+  //     width: 900,
+  //     widthResize: 1200
+  //   };
 
-    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
+  //   const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
 
-    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
-    expect(pluginOptions).toMatchObject({
-      width: options.widthResize
-    })
-  });
+  //   expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}`);
+  //   expect(pluginOptions).toMatchObject({
+  //     width: options.widthResize
+  //   })
+  // });
 
-  it('should return resize override with original size in URL if resize is the same as width', () => {
-    const cldImage = cld.image(TEST_PUBLIC_ID);
-    const options = {
-      width: 900,
-      widthResize: 900
-    };
+  // it('should return resize override with original size in URL if resize is the same as width', () => {
+  //   const cldImage = cld.image(TEST_PUBLIC_ID);
+  //   const options = {
+  //     width: 900,
+  //     widthResize: 900
+  //   };
 
-    const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
+  //   const { options: pluginOptions } = plugin({ cldAsset: cldImage, options });
 
-    expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}/${TEST_PUBLIC_ID}`);
-    expect(pluginOptions).toMatchObject({
-      width: options.widthResize
-    })
-  });
+  //   expect(cldImage.toURL()).toContain(`image/upload/c_limit,w_${options.width}`);
+  //   expect(pluginOptions).toMatchObject({
+  //     width: options.widthResize
+  //   })
+  // });
 
   it('should not apply a height when crop is fill if isnt set', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);
@@ -107,8 +107,8 @@ describe('Cropping plugin', () => {
       width: 100,
       crop: 'fill',
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`c_${options.crop},w_${options.width},g_auto/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_${options.crop},w_${options.width},g_auto`);
   });
 
   it('should apply aspect ratio as a string and valid crop', () => {
@@ -117,8 +117,8 @@ describe('Cropping plugin', () => {
       aspectRatio: '16:9',
       crop: 'fill'
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).toContain(`c_fill,ar_16:9,g_auto/${TEST_PUBLIC_ID}`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toContain(`c_fill,ar_16:9,g_auto`);
   });
 
   it('should apply aspect ratio as a float and valid crop', () => {
@@ -127,19 +127,19 @@ describe('Cropping plugin', () => {
       aspectRatio: .5,
       crop: 'fill'
     };
-    plugin({ cldAsset: cldImage, options });
+    const { resize } = plugin({ cldAsset: cldImage, options });
     // for my own sanity that float => string will add the leading 0
     expect(`${options.aspectRatio}`).toMatch('0.5');
-    expect(cldImage.toURL()).toContain(`c_fill,ar_${options.aspectRatio},g_auto/${TEST_PUBLIC_ID}`);
+    expect(resize).toContain(`c_fill,ar_${options.aspectRatio},g_auto`);
   });
 
   it('should not apply aspect ratio if not a valid crop', () => {
     const cldImage = cld.image(TEST_PUBLIC_ID);
     const options = {
       aspectRatio: '16:9',
+      crop: 'fit'
     };
-    plugin({ cldAsset: cldImage, options });
-    expect(cldImage.toURL()).not.toContain(`ar_16:9`);
+    const { resize } = plugin({ cldAsset: cldImage, options });
+    expect(resize).toBeUndefined();
   });
-
 });

--- a/packages/url-loader/tests/plugins/fill-background.spec.js
+++ b/packages/url-loader/tests/plugins/fill-background.spec.js
@@ -16,7 +16,6 @@ const TEST_PUBLIC_ID = 'test-public-id';
 describe('Plugins', () => {
   describe('Fill Background', () => {
     it('should generate a background with basic settings', () => {
-
       const cldImage = cld.image(TEST_PUBLIC_ID);
 
       const options = {
@@ -30,11 +29,10 @@ describe('Plugins', () => {
         options
       });
 
-      expect(cldImage.toURL()).toContain(`b_gen_fill,ar_${options.width}:${options.height},w_${options.width},c_pad/${TEST_PUBLIC_ID}`);
+      expect(cldImage.toURL()).toContain(`b_gen_fill,ar_${options.width}:${options.height},c_pad/${TEST_PUBLIC_ID}`);
     });
 
     it('should generate with custom options', () => {
-
       const cldImage = cld.image(TEST_PUBLIC_ID);
 
       const options = {
@@ -52,7 +50,7 @@ describe('Plugins', () => {
         options
       });
 
-      expect(cldImage.toURL()).toContain(`b_gen_fill:${encodeURIComponent(options.fillBackground.prompt)},ar_${options.width}:${options.height},w_${options.width},c_${options.fillBackground.crop},g_${options.fillBackground.gravity}/${TEST_PUBLIC_ID}`);
+      expect(cldImage.toURL()).toContain(`b_gen_fill:${encodeURIComponent(options.fillBackground.prompt)},ar_${options.width}:${options.height},c_${options.fillBackground.crop},g_${options.fillBackground.gravity}/${TEST_PUBLIC_ID}`);
     });
   });
 });


### PR DESCRIPTION
# Description

This reworks cropping and resizing to support a bigger effort to correctly apply these transformations at the right point within the transformation string.

The current mechanism applies the core width and height to the front of the transformation string, with the idea of providing a "canvas" for someone to work from, but this is unintuitive, where a width and height would be the expected final resize, which may not be the case with other transformations (particularly dynamically generated responsive images).

This removes the widthResize property which applied the transformation the end, where the core width and height resizing now takes place.

To fill in for use cases where it made sense to apply a "base" cropping and resizing effect, a new `base*` property was added for width, height, crop, gravity, and zoom, to accommodate the situation where one might want to resize, apply transformations, then obtain the true width and height with a final resize as part of a 2-stage crop and resize.

In the example where 

**Somewhat of a tl;dr**
This PR primarily reverses the order in which the parameters are applied, opting for the primary width and height to be the final transformation applied to avoid attempting to more accurately describe what the user's intent is when passing in a width and height. As such, the name of the options for the 1st stage is now `base*`

**Examples**

Previously when using an effect with a width:
```
constructCloudinaryUrl({
  options: {
    width: 100,
    grayscale: true
  }
})
```

The resulting transformation would yield: `c_limit,w_960/e_grayscale`

However, it would now yield: `e_grayscale/c_limit,w_960`

This is more relevant when using the 2-stage resizing, where previously:

```
constructCloudinaryUrl({
  options: {
    width: 100,
    widthResize: 200
  }
})
```

The resulting transformation would yield: `c_limit,w_100/c_limit,w_200`

Where now:

```
constructCloudinaryUrl({
  options: {
    width: 100,
    baseResize: 200
  }
})
```
The resulting transformation would yield: `c_limit,w_200/c_limit,w_100`

**Use Case**

A big use case around why this is important is limiting the size of an image prematurely.

In an example such as:
```
constructCloudinaryUrl({
  options: {
    width: 100,
    widthResize: 200
  }
})
```

The resulting transformation would yield: `c_limit,w_100/c_limit,w_200`

This is problematic if the original image is greater than or equal to 200, as with the first transformation applied, the image will not be able to be sized organically above 100. If using a crop that allows upscaling, it would not result in using the original image, meaning it would scale to 200 with reduced quality.

The effect is largely the same in what it achieves, but the use case and intent should be more accurate with this PR.

Relevant: https://github.com/cloudinary-community/next-cloudinary/issues/327